### PR TITLE
Support custom alphabet from file

### DIFF
--- a/src/alphabet.rs
+++ b/src/alphabet.rs
@@ -79,7 +79,7 @@ impl Alphabet {
         })
     }
 
-    fn new_static_from_text(s: &str) -> error::Returns<Self> {
+    pub fn new_static_from_text(s: &str) -> error::Returns<Self> {
         let mut tiles = Vec::new();
         for line_str in s.lines() {
             let mut tokens = line_str.split_whitespace();

--- a/src/main_build.rs
+++ b/src/main_build.rs
@@ -462,6 +462,8 @@ fn main() -> error::Returns<()> {
     this is applicable for kwg, kwg-anything, klv/klv2)
   (english can also be catalan, dutch, french, german, norwegian, polish,
     slovene, spanish, decimal, hex)
+  (english can also be custom, with an extra alphabet file argument:
+    custom-kwg alphabet.txt words.txt out.kwg)
 input/output files can be \"-\" (not advisable for binary files)"
         );
         Ok(())
@@ -482,6 +484,18 @@ input/output files can be \"-\" (not advisable for binary files)"
             || do_lang(&args, "decimal", alphabet::make_decimal_alphabet)?
             || do_lang(&args, "hex", alphabet::make_hex_alphabet)?
         {
+        } else if args[1].starts_with("custom-") {
+            if args.len() < 3 {
+                return Err("need alphabet file".into());
+            }
+            let alph_text = std::fs::read_to_string(&args[2])?;
+            let mut shifted_args = vec![args[0].clone(), args[1].clone()];
+            shifted_args.extend_from_slice(&args[3..]);
+            if !do_lang(&shifted_args, "custom", || {
+                alphabet::Alphabet::new_static_from_text(&alph_text).unwrap()
+            })? {
+                return Err("invalid argument".into());
+            }
         } else {
             return Err("invalid argument".into());
         }

--- a/src/main_read.rs
+++ b/src/main_read.rs
@@ -2725,6 +2725,8 @@ fn main() -> error::Returns<()> {
     generate .wmp v3
   (english can also be catalan, dutch, french, german, norwegian, polish,
     slovene, spanish, decimal, hex)
+  (english can also be custom, with an extra alphabet file argument:
+    custom-kwg alphabet.txt CSW24.kwg CSW24.txt)
   klv-kwg-extract CSW24.klv2 racks.kwg
     just copy out the kwg for further analysis.
   kwg-hitcheck CSW24.kwg cls csa ncs outfile
@@ -2784,6 +2786,18 @@ input/output files can be \"-\" (not advisable for binary files)"
                 alphabet::make_hong_kong_english_alphabet,
             )?
         {
+        } else if args[1].starts_with("custom-") {
+            if args.len() < 3 {
+                return Err("need alphabet file".into());
+            }
+            let alph_text = std::fs::read_to_string(&args[2])?;
+            let mut shifted_args = vec![args[0].clone(), args[1].clone()];
+            shifted_args.extend_from_slice(&args[3..]);
+            if !do_lang(&shifted_args, "custom", || {
+                alphabet::Alphabet::new_static_from_text(&alph_text).unwrap()
+            })? {
+                return Err("invalid argument".into());
+            }
         } else if args[1] == "klv-kwg-extract" {
             let klv_bytes = &read_to_end(&mut make_reader(&args[2])?)?;
             let parts = parse_klv(klv_bytes)?;


### PR DESCRIPTION
## Summary
- Make `Alphabet::new_static_from_text` public
- Add `custom` language prefix to buildlex and read that loads an alphabet from a file
- Usage: `custom-kwg alphabet.txt words.txt out.kwg` (extra alphabet file arg, rest shifts by one)
- All existing subcommands work with `custom` (kwg, kbwg, klv, klv2, klv16, kwg-dawg, kwg-alpha, sort-words, wmp, anagram, check, etc.)

## Test plan
- [x] Verify `cargo check` passes
- [x] `custom-kwg` with english alphabet produces identical output to `english-kwg`
- [x] `custom-kwg-dawg` and `custom-kwg-alpha` produce identical output
- [x] `custom-klv`, `custom-klv2`, and `custom-klv16` build identical output
- [x] `custom-kbwg` build identical output
- [x] `custom-sort-words` and `custom-sort-leaves` identical output
- [x] `read custom-kwg` round-trips correctly
- [x] `read custom-kbwg` round-trips correctly
- [x] `read custom-klv` (klv2), `read custom-klv16` round-trip correctly
- [x] `read custom-kwg-check`, `custom-kwg-gaddag`, `custom-kwg-nodes`, `custom-kwg-anagram` identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>