### PR TITLE
fix MultiLeaves overflow: exchange fallback and endgame leaves

### DIFF
--- a/src/klv.rs
+++ b/src/klv.rs
@@ -285,16 +285,6 @@ impl MultiLeaves {
         self.leave_values[0] = play_out_bonus;
     }
 
-    // undefined behavior unless rack_tally is a subset of what was init'ed.
-    #[inline(always)]
-    pub fn leave_value_from_tally(&self, rack_tally: &[u8]) -> f32 {
-        let mut leave_idx = 0u32;
-        for &tile in &self.unique_tiles {
-            leave_idx += rack_tally[tile as usize] as u32 * self.digits[tile as usize].place_value;
-        }
-        self.leave_values[leave_idx as usize]
-    }
-
     // Compute best_leave_values by traversing the KLV's KWG, constrained by
     // available tiles. Used when the dense array is too large to build.
     // Traverses KLV entries (bounded by KLV size) rather than rack subsets.

--- a/src/klv.rs
+++ b/src/klv.rs
@@ -444,6 +444,58 @@ impl MultiLeaves {
         !self.leave_values.is_empty()
     }
 
+    // Exchange generator that computes leave values on-the-fly via KLV.
+    // Used when the dense leave table is not available.
+    pub fn gen_exchange_moves_via_klv<'a, FoundExchangeMove: FnMut(&[u8], f32), L: kwg::Node>(
+        klv: &Klv<L>,
+        found_exchange_move: FoundExchangeMove,
+        rack_tally: &'a mut [u8],
+        exchange_buffer: &'a mut Vec<u8>,
+        max_vec_len: usize,
+    ) {
+        exchange_buffer.clear();
+        struct ExchangeEnv<'a, FoundExchangeMove: FnMut(&[u8], f32), L: kwg::Node> {
+            rack_tally_len: u8,
+            klv: &'a Klv<L>,
+            found_exchange_move: FoundExchangeMove,
+            rack_tally: &'a mut [u8],
+            exchange_buffer: &'a mut Vec<u8>,
+            max_vec_len: usize,
+        }
+        fn generate_exchanges<FoundExchangeMove: FnMut(&[u8], f32), L: kwg::Node>(
+            env: &mut ExchangeEnv<'_, FoundExchangeMove, L>,
+            tile_offset: u8,
+        ) {
+            if !env.exchange_buffer.is_empty() {
+                let leave_value = env.klv.leave_value_from_tally(env.rack_tally);
+                (env.found_exchange_move)(env.exchange_buffer, leave_value);
+            }
+            if env.exchange_buffer.len() < env.max_vec_len {
+                for tile in tile_offset..env.rack_tally_len {
+                    let tile_usize = tile as usize;
+                    if env.rack_tally[tile_usize] > 0 {
+                        env.rack_tally[tile_usize] -= 1;
+                        env.exchange_buffer.push(tile);
+                        generate_exchanges(env, tile);
+                        env.exchange_buffer.pop();
+                        env.rack_tally[tile_usize] += 1;
+                    }
+                }
+            }
+        }
+        generate_exchanges(
+            &mut ExchangeEnv {
+                rack_tally_len: rack_tally.len() as u8,
+                klv,
+                found_exchange_move,
+                rack_tally,
+                exchange_buffer,
+                max_vec_len,
+            },
+            0,
+        );
+    }
+
     #[inline(always)]
     pub fn pass_leave_idx(&self) -> u32 {
         if self.leave_values.is_empty() {

--- a/src/main_movegen_test.rs
+++ b/src/main_movegen_test.rs
@@ -7,6 +7,7 @@ struct TestCase {
     rack: &'static str,
     max_gen: usize,
     always_include_pass: bool,
+    num_exchanges_by_this_player: i16,
 }
 
 static TEST_CASES: &[TestCase] = &[
@@ -16,6 +17,7 @@ static TEST_CASES: &[TestCase] = &[
         rack: "AEINRST",
         max_gen: 15,
         always_include_pass: false,
+        num_exchanges_by_this_player: 0,
     },
     // Empty board, rack with blank
     TestCase {
@@ -23,6 +25,7 @@ static TEST_CASES: &[TestCase] = &[
         rack: "?SATIRE",
         max_gen: 15,
         always_include_pass: false,
+        num_exchanges_by_this_player: 0,
     },
     // After one move through center
     TestCase {
@@ -30,6 +33,7 @@ static TEST_CASES: &[TestCase] = &[
         rack: "AEIOULD",
         max_gen: 15,
         always_include_pass: false,
+        num_exchanges_by_this_player: 0,
     },
     // One word through center, always_include_pass=true (compare with case 10)
     TestCase {
@@ -37,6 +41,7 @@ static TEST_CASES: &[TestCase] = &[
         rack: "MOOORRT",
         max_gen: 15,
         always_include_pass: false,
+        num_exchanges_by_this_player: 0,
     },
     // Hooks and blanks
     TestCase {
@@ -44,6 +49,7 @@ static TEST_CASES: &[TestCase] = &[
         rack: "?STLING",
         max_gen: 15,
         always_include_pass: false,
+        num_exchanges_by_this_player: 0,
     },
     // Cross words
     TestCase {
@@ -51,6 +57,7 @@ static TEST_CASES: &[TestCase] = &[
         rack: "ABCDEFG",
         max_gen: 15,
         always_include_pass: false,
+        num_exchanges_by_this_player: 0,
     },
     // Bingo rack, few tiles on board
     TestCase {
@@ -58,6 +65,7 @@ static TEST_CASES: &[TestCase] = &[
         rack: "RETINAS",
         max_gen: 15,
         always_include_pass: false,
+        num_exchanges_by_this_player: 0,
     },
     // Terrible rack, exchanges should appear
     TestCase {
@@ -65,6 +73,7 @@ static TEST_CASES: &[TestCase] = &[
         rack: "UUVVIIQ",
         max_gen: 30,
         always_include_pass: false,
+        num_exchanges_by_this_player: 0,
     },
     // Only 2 tiles, limited plays, with always_include_pass=true
     TestCase {
@@ -72,6 +81,7 @@ static TEST_CASES: &[TestCase] = &[
         rack: "CS",
         max_gen: 15,
         always_include_pass: true,
+        num_exchanges_by_this_player: 0,
     },
     // Double blank
     TestCase {
@@ -79,6 +89,7 @@ static TEST_CASES: &[TestCase] = &[
         rack: "??",
         max_gen: 15,
         always_include_pass: false,
+        num_exchanges_by_this_player: 0,
     },
     // Same as case 3 but always_include_pass=false, pass should not appear
     TestCase {
@@ -86,6 +97,7 @@ static TEST_CASES: &[TestCase] = &[
         rack: "MOOORRT",
         max_gen: 15,
         always_include_pass: false,
+        num_exchanges_by_this_player: 0,
     },
     // Late game (ZONULE position, 73 tiles)
     TestCase {
@@ -93,6 +105,7 @@ static TEST_CASES: &[TestCase] = &[
         rack: "ST",
         max_gen: 15,
         always_include_pass: false,
+        num_exchanges_by_this_player: 0,
     },
     // Same position, rack with few useful plays, pass not included
     TestCase {
@@ -100,6 +113,7 @@ static TEST_CASES: &[TestCase] = &[
         rack: "OO",
         max_gen: 15,
         always_include_pass: false,
+        num_exchanges_by_this_player: 0,
     },
     // Same as above but always_include_pass=true, pass should appear
     TestCase {
@@ -107,6 +121,7 @@ static TEST_CASES: &[TestCase] = &[
         rack: "OO",
         max_gen: 100,
         always_include_pass: true,
+        num_exchanges_by_this_player: 0,
     },
     // Bag empty (80 tiles on board, bag=6 < 7), no exchanges possible
     TestCase {
@@ -114,6 +129,7 @@ static TEST_CASES: &[TestCase] = &[
         rack: "VUAENRU",
         max_gen: 15,
         always_include_pass: false,
+        num_exchanges_by_this_player: 0,
     },
     // Same position, single tile, no valid plays, pass generated as fallback
     TestCase {
@@ -121,6 +137,7 @@ static TEST_CASES: &[TestCase] = &[
         rack: "V",
         max_gen: 15,
         always_include_pass: false,
+        num_exchanges_by_this_player: 0,
     },
     // Large rack (threat analysis: all unseen tiles), MultiLeaves overflow
     TestCase {
@@ -128,6 +145,7 @@ static TEST_CASES: &[TestCase] = &[
         rack: "??AAAAAAAAABBCDDDDEEEEEEEEEEEEFFGGGHHIIIIIIIIIJKLLLLMMNNNNNNOOOOOOOOPPQRRRRRRSSSSTTTTTTUVVWWXYYZ",
         max_gen: 5,
         always_include_pass: false,
+        num_exchanges_by_this_player: i16::MAX, // skip exchanges for threat analysis
     },
 ];
 
@@ -184,7 +202,7 @@ fn main() -> error::Returns<()> {
             board_snapshot: &board_snapshot,
             rack: &rack,
             max_gen: case.max_gen,
-            num_exchanges_by_this_player: 0,
+            num_exchanges_by_this_player: case.num_exchanges_by_this_player,
             always_include_pass: case.always_include_pass,
         });
         let elapsed = t0.elapsed();

--- a/src/movegen.rs
+++ b/src/movegen.rs
@@ -68,6 +68,7 @@ struct WorkingBuffer {
     transposed_board_tiles: Box<[u8]>,                 // c*r
     num_tiles_on_board: u16,
     num_tiles_in_bag: i16, // negative when players also have less than full racks
+    play_out_bonus: f32,
     num_tiles_on_rack: u8,
     rack_bits: u64, // bit 0 = blank conveniently matches bit 0 = have cross set
     multi_leaves: klv::MultiLeaves,
@@ -126,6 +127,7 @@ impl Clone for WorkingBuffer {
             transposed_board_tiles: self.transposed_board_tiles.clone(),
             num_tiles_on_board: self.num_tiles_on_board,
             num_tiles_in_bag: self.num_tiles_in_bag,
+            play_out_bonus: self.play_out_bonus,
             num_tiles_on_rack: self.num_tiles_on_rack,
             rack_bits: self.rack_bits,
             multi_leaves: self.multi_leaves.clone(),
@@ -189,6 +191,7 @@ impl Clone for WorkingBuffer {
         self.num_tiles_on_board
             .clone_from(&source.num_tiles_on_board);
         self.num_tiles_in_bag.clone_from(&source.num_tiles_in_bag);
+        self.play_out_bonus.clone_from(&source.play_out_bonus);
         self.num_tiles_on_rack.clone_from(&source.num_tiles_on_rack);
         self.rack_bits.clone_from(&source.rack_bits);
         self.multi_leaves.clone_from(&source.multi_leaves);
@@ -278,6 +281,7 @@ impl WorkingBuffer {
             transposed_board_tiles: vec![0u8; rows_times_cols].into_boxed_slice(),
             num_tiles_on_board: 0,
             num_tiles_in_bag: 0,
+            play_out_bonus: 0.0,
             num_tiles_on_rack: 0,
             rack_bits: 0,
             multi_leaves: klv::MultiLeaves::new(),
@@ -401,6 +405,7 @@ impl WorkingBuffer {
         } else {
             0.0
         };
+        self.play_out_bonus = play_out_bonus;
 
         // eg if my rack is ZY??YVA it'd be [10,4,4,4,1,0,0].
         self.descending_scores.clear();
@@ -1428,6 +1433,8 @@ struct GenPlaceMovesParams<'a, CallbackType: FnMut(i8, &[u8], i32, f32), N: kwg:
     rightmost: i8,
     callback: CallbackType,
     multi_leaves: &'a klv::MultiLeaves,
+    num_tiles_in_bag: i16,
+    play_out_bonus: f32,
     used_letters_tally: &'a mut [u8], // jumbled mode only
     accepts_alpha_cache: &'a mut [([u8; 64], bool)], // jumbled mode only
 }
@@ -1469,6 +1476,16 @@ fn gen_classic_place_moves<
                 .num_played_bonus(env.num_played) as i32;
         let leave_value = if env.params.multi_leaves.is_dense() {
             env.params.multi_leaves.leave_value(acc.leave_idx)
+        } else if env.params.num_tiles_in_bag <= 0 {
+            let is_played_out = env.params.rack_tally.iter().all(|&count| count == 0);
+            if is_played_out {
+                env.params.play_out_bonus
+            } else {
+                let residual: i32 = (0u8..).zip(env.params.rack_tally.iter()).map(|(tile, &count)| {
+                    count as i32 * env.params.board_snapshot.game_config.alphabet().score(tile) as i32
+                }).sum();
+                (-10 - 2 * residual) as f32
+            }
         } else {
             env.params
                 .board_snapshot
@@ -1800,6 +1817,16 @@ fn gen_jumbled_place_moves<
                     .num_played_bonus(env.num_played) as i32;
             let leave_value = if env.params.multi_leaves.is_dense() {
                 env.params.multi_leaves.leave_value(acc.leave_idx)
+            } else if env.params.num_tiles_in_bag <= 0 {
+                let is_played_out = env.params.rack_tally.iter().all(|&count| count == 0);
+                if is_played_out {
+                    env.params.play_out_bonus
+                } else {
+                    let residual: i32 = (0u8..).zip(env.params.rack_tally.iter()).map(|(tile, &count)| {
+                        count as i32 * env.params.board_snapshot.game_config.alphabet().score(tile) as i32
+                    }).sum();
+                    (-10 - 2 * residual) as f32
+                }
             } else {
                 env.params
                     .board_snapshot
@@ -2146,6 +2173,8 @@ fn gen_place_moves_at<
                 )
             },
             multi_leaves,
+            num_tiles_in_bag: working_buffer.num_tiles_in_bag,
+            play_out_bonus: working_buffer.play_out_bonus,
             used_letters_tally: &mut working_buffer.used_letters_tally,
             accepts_alpha_cache: &mut working_buffer.accepts_alpha_cache,
         },

--- a/src/movegen.rs
+++ b/src/movegen.rs
@@ -423,8 +423,10 @@ impl WorkingBuffer {
                 false,
                 adjust_leave_value,
             );
-            self.multi_leaves
-                .init_endgame_leaves(|tile| alphabet.score(tile), play_out_bonus);
+            if self.multi_leaves.is_dense() {
+                self.multi_leaves
+                    .init_endgame_leaves(|tile| alphabet.score(tile), play_out_bonus);
+            }
             // the multi_leaves is correct but doing this directly is faster.
             self.best_leave_values.clear();
             self.best_leave_values

--- a/src/movegen.rs
+++ b/src/movegen.rs
@@ -2792,14 +2792,23 @@ fn kurnia_gen_exchange_moves<
 ) {
     if working_buffer.num_tiles_in_bag >= board_snapshot.game_config.exchange_tile_limit()
         && num_exchanges_by_this_player < board_snapshot.game_config.exchanges_allowed_per_player()
-        && multi_leaves.is_dense()
     {
-        multi_leaves.kurnia_gen_exchange_moves_unconditionally(
-            found_exchange_move,
-            &mut working_buffer.rack_tally,
-            &mut working_buffer.exchange_buffer,
-            working_buffer.num_tiles_in_bag as usize,
-        );
+        if multi_leaves.is_dense() {
+            multi_leaves.kurnia_gen_exchange_moves_unconditionally(
+                found_exchange_move,
+                &mut working_buffer.rack_tally,
+                &mut working_buffer.exchange_buffer,
+                working_buffer.num_tiles_in_bag as usize,
+            );
+        } else {
+            klv::MultiLeaves::gen_exchange_moves_via_klv(
+                board_snapshot.klv,
+                found_exchange_move,
+                &mut working_buffer.rack_tally,
+                &mut working_buffer.exchange_buffer,
+                working_buffer.num_tiles_in_bag as usize,
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to PR #7. Fixes issues discovered with oversized racks:

- **`57f0b48` remove dead MultiLeaves::leave_value_from_tally** — unused, all callers use Klv:: or dense leave_value(idx)
- **`51e409f` generate exchanges via KLV fallback when MultiLeaves is not dense** — exchanges no longer silently skipped for large racks; callers can pass `num_exchanges_by_this_player: i16::MAX` to skip
- **`c018f92` guard init_endgame_leaves when MultiLeaves is not dense** — prevent crash on empty leave_values
- **`f60f560` fix endgame leave values when MultiLeaves is not dense** — compute penalty on-the-fly (-10 - 2*residual or play_out_bonus) instead of wrong KLV values
- **`9d495cf` add num_exchanges_by_this_player to movegen test** — large rack case uses i16::MAX

## Test plan

- [x] `cargo clippy` clean
- [x] `movegen-test --check` passes
- [x] Verified with forced overflow (threshold=0): place move equities identical to dense path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>