### PR TITLE
Encapsulate Bag; double-ended drawing

### DIFF
--- a/src/bag.rs
+++ b/src/bag.rs
@@ -3,137 +3,235 @@
 use super::alphabet;
 use rand::prelude::*;
 
-pub struct Bag(Vec<u8>);
+pub struct Bag {
+    tiles: Vec<u8>,
+    fc: usize, // front cursor: tiles[0..fc] is dead space, tiles[fc..] is playable
+}
 
 impl Bag {
     pub fn new(alphabet: &alphabet::Alphabet) -> Bag {
-        let mut bag = Vec::with_capacity(
-            (0..alphabet.len())
-                .map(|tile| alphabet.freq(tile) as usize)
-                .sum(),
-        );
+        let total_tiles: usize = (0..alphabet.len())
+            .map(|tile| alphabet.freq(tile) as usize)
+            .sum();
+        let mut tiles = Vec::with_capacity(total_tiles + 16);
         for tile in 0..alphabet.len() {
             for _ in 0..alphabet.freq(tile) {
-                bag.push(tile);
+                tiles.push(tile);
             }
         }
-        Bag(bag)
+        Bag { tiles, fc: 0 }
     }
 
     pub fn shuffle(&mut self, mut rng: &mut dyn Rng) {
-        self.0.shuffle(&mut rng);
+        self.tiles[self.fc..].shuffle(&mut rng);
     }
 
     pub fn shuffle_n(&mut self, mut rng: &mut dyn Rng, amount: usize) {
         // this "correctly" puts the shuffled amount at the end
-        self.0.partial_shuffle(&mut rng, amount);
+        self.tiles[self.fc..].partial_shuffle(&mut rng, amount);
     }
 
     pub fn pop(&mut self) -> Option<u8> {
-        self.0.pop()
+        self.pop_back()
     }
 
-    pub fn replenish(&mut self, rack: &mut Vec<u8>, rack_size: usize) {
-        for _ in 0..(rack_size - rack.len()).min(self.0.len()) {
-            rack.push(self.pop().unwrap());
+    pub fn pop_back(&mut self) -> Option<u8> {
+        if self.tiles.len() > self.fc {
+            self.tiles.pop()
+        } else {
+            None
+        }
+    }
+
+    pub fn pop_front(&mut self) -> Option<u8> {
+        if self.fc < self.tiles.len() {
+            let tile = self.tiles[self.fc];
+            self.fc += 1;
+            Some(tile)
+        } else {
+            None
+        }
+    }
+
+    // Even players draw from back, odd players draw from front.
+    pub fn replenish(&mut self, rack: &mut Vec<u8>, rack_size: usize, player_index: usize) {
+        if player_index.is_multiple_of(2) {
+            self.replenish_back(rack, rack_size);
+        } else {
+            self.replenish_front(rack, rack_size);
+        }
+    }
+
+    pub fn replenish_back(&mut self, rack: &mut Vec<u8>, rack_size: usize) {
+        let playable = self.tiles.len() - self.fc;
+        for _ in 0..(rack_size - rack.len()).min(playable) {
+            rack.push(self.pop_back().unwrap());
+        }
+    }
+
+    pub fn replenish_front(&mut self, rack: &mut Vec<u8>, rack_size: usize) {
+        let playable = self.tiles.len() - self.fc;
+        for _ in 0..(rack_size - rack.len()).min(playable) {
+            rack.push(self.pop_front().unwrap());
         }
     }
 
     pub fn return_tiles(&mut self, tiles: &[u8]) {
-        self.0.extend_from_slice(tiles);
+        self.tiles.extend_from_slice(tiles);
     }
 
     pub fn return_tile(&mut self, tile: u8) {
-        self.0.push(tile);
+        self.tiles.push(tile);
     }
 
     pub fn set_from_iter<I: IntoIterator<Item = u8>>(&mut self, iter: I) {
-        self.0.clear();
-        self.0.extend(iter);
+        self.tiles.clear();
+        self.fc = 0;
+        self.tiles.extend(iter);
     }
 
     pub fn as_slice(&self) -> &[u8] {
-        &self.0
+        &self.tiles[self.fc..]
     }
 
     pub fn len(&self) -> usize {
-        self.0.len()
+        self.tiles.len() - self.fc
     }
 
     pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
+        self.tiles.len() <= self.fc
     }
 
-    pub fn swap_remove_tile(&mut self, tile: u8) -> Option<()> {
-        self.0.iter().rposition(|&t| t == tile).map(|pos| {
-            self.0.swap_remove(pos);
-        })
+    // Order-preserving removal: shift right portion left, pop.
+    pub fn remove_tile(&mut self, tile: u8) -> Option<()> {
+        self.tiles[self.fc..]
+            .iter()
+            .rposition(|&t| t == tile)
+            .map(|pos| {
+                let abs_pos = self.fc + pos;
+                let len = self.tiles.len();
+                self.tiles.copy_within(abs_pos + 1..len, abs_pos);
+                self.tiles.pop();
+            })
     }
 
-    // put back the tiles in random order. keep the rest of the bag in the same order.
-    pub fn put_back(&mut self, mut rng: &mut dyn Rng, tiles: &[u8]) {
-        let mut num_new_tiles = tiles.len();
-        match num_new_tiles {
-            0 => {
-                return;
-            }
-            1 => {
-                self.0.insert(rng.random_range(0..=self.0.len()), unsafe {
-                    *tiles.get_unchecked(0)
-                });
-                return;
-            }
-            _ => {}
-        }
-        let mut num_old_tiles = self.0.len();
-        let num_same_prefix = rng.random_range(0..=num_old_tiles);
-        if num_same_prefix == num_old_tiles {
-            // old does not move
-            self.0.extend_from_slice(tiles); // [old,new]
-            unsafe { self.0.get_unchecked_mut(num_old_tiles..) }.shuffle(&mut rng);
+    // Put back m tiles in random order. Keep the existing n tiles in order.
+    // If fc >= m: vec.len() unchanged, fc -= m (no allocation).
+    // If fc < m: vec.len() += m, fc unchanged.
+    pub fn put_back(&mut self, rng: &mut dyn Rng, tiles: &[u8]) {
+        let m = tiles.len();
+        if m == 0 {
             return;
         }
-        let new_len = num_new_tiles + num_old_tiles;
-        self.0.reserve(num_new_tiles + new_len); // cap = old+(new+old)+new
-        #[allow(clippy::uninit_vec)]
-        unsafe {
-            self.0.set_len(new_len + num_old_tiles);
-        } // [old,?,?]
-        let mut p_old_tiles = new_len; // after old+new
-        self.0
-            .copy_within(num_same_prefix..num_old_tiles, p_old_tiles); // [old,?,ld?]
-        num_old_tiles -= num_same_prefix;
-        let mut p_new_tiles = self.0.len(); // after old+new+old
-        self.0.extend_from_slice(tiles); // [old,?,ld?,new]
-        unsafe { self.0.get_unchecked_mut(p_new_tiles..) }.shuffle(&mut rng);
-        num_new_tiles -= 1;
-        unsafe {
-            *self.0.get_unchecked_mut(num_same_prefix) =
-                *self.0.get_unchecked(p_new_tiles + num_new_tiles);
-        }
-        for wp in num_same_prefix + 1..new_len {
-            if if num_new_tiles == 0 {
-                true
-            } else if num_old_tiles == 0 {
-                false
+        let n = self.len();
+        if m == 1 {
+            // Insert 1 tile at a uniformly random position among n+1 slots.
+            let pos = rng.random_range(0..n + 1);
+            if self.fc >= 1 {
+                self.fc -= 1;
+                self.tiles
+                    .copy_within(self.fc + 1..self.fc + 1 + pos, self.fc);
             } else {
-                rng.random_range(0..num_old_tiles + num_new_tiles) < num_old_tiles
-            } {
-                unsafe {
-                    *self.0.get_unchecked_mut(wp) = *self.0.get_unchecked(p_old_tiles);
-                }
-                p_old_tiles += 1;
-                num_old_tiles -= 1;
-            } else {
-                unsafe {
-                    *self.0.get_unchecked_mut(wp) = *self.0.get_unchecked(p_new_tiles);
-                }
-                p_new_tiles += 1;
-                num_new_tiles -= 1;
+                self.tiles.push(0);
+                self.tiles
+                    .copy_within(self.fc + pos..self.fc + n, self.fc + pos + 1);
             }
+            self.tiles[self.fc + pos] = tiles[0];
+            return;
         }
-        unsafe {
-            self.0.set_len(new_len);
+        if m == 2 {
+            // Insert 2 tiles at 2 uniformly random positions among n+2 slots.
+            // The swap doubles as a coin flip for tile assignment order,
+            // giving all (n+2)(n+1) ordered arrangements uniformly.
+            let a = rng.random_range(0..n + 1);
+            let b = rng.random_range(0..n + 2);
+            let (a, b, first, second) = if a < b {
+                (a, b, tiles[0], tiles[1])
+            } else {
+                (b, a + 1, tiles[1], tiles[0])
+            };
+            if self.fc >= 2 {
+                self.fc -= 2;
+                // Old at fc+2..fc+2+n. Left-to-right:
+                // old[0..a] shift -2, old[a..b-1] shift -1, old[b-1..n] stays.
+                self.tiles
+                    .copy_within(self.fc + 2..self.fc + 2 + a, self.fc);
+                self.tiles[self.fc + a] = first;
+                self.tiles
+                    .copy_within(self.fc + 2 + a..self.fc + 1 + b, self.fc + a + 1);
+                self.tiles[self.fc + b] = second;
+            } else {
+                self.tiles.resize(self.fc + n + 2, 0);
+                // Old at fc..fc+n. Right-to-left:
+                // old[b-1..n] shift +2, old[a..b-1] shift +1, old[0..a] stays.
+                self.tiles
+                    .copy_within(self.fc + b - 1..self.fc + n, self.fc + b + 1);
+                self.tiles[self.fc + b] = second;
+                self.tiles
+                    .copy_within(self.fc + a..self.fc + b - 1, self.fc + a + 1);
+                self.tiles[self.fc + a] = first;
+            }
+            return;
+        }
+        // General case: m >= 3. Interleave with Fisher-Yates probability.
+        // Safety: wp and old_ptr stay in fc..fc+m+n = 0..tiles.len().
+        // Left-to-right: wp <= old_ptr because new_placed <= m.
+        // Right-to-left: wp >= old_ptr because new_placed <= m.
+        // pick < remaining_new <= m <= 16 = new_buf.len().
+        let mut new_buf = [0u8; 16];
+        new_buf[..m].copy_from_slice(tiles);
+        let mut remaining_new = m;
+        let mut remaining_old = n;
+        if self.fc >= m {
+            // Dead space: left-to-right (wp <= old_ptr since new_placed <= m).
+            self.fc -= m;
+            let mut old_ptr = self.fc + m;
+            for wp in self.fc..self.fc + m + n {
+                if remaining_new == 0 {
+                    break; // old_ptr == wp; remaining old tiles are already in place.
+                }
+                if remaining_old > 0
+                    && rng.random_range(0..remaining_new + remaining_old) >= remaining_new
+                {
+                    unsafe {
+                        *self.tiles.get_unchecked_mut(wp) = *self.tiles.get_unchecked(old_ptr);
+                    }
+                    old_ptr += 1;
+                    remaining_old -= 1;
+                } else {
+                    let pick = rng.random_range(0..remaining_new);
+                    unsafe {
+                        *self.tiles.get_unchecked_mut(wp) = *new_buf.get_unchecked(pick);
+                    }
+                    remaining_new -= 1;
+                    new_buf.swap(pick, remaining_new);
+                }
+            }
+        } else {
+            // Grow: right-to-left (wp >= old_ptr since new_placed <= m).
+            self.tiles.resize(self.fc + n + m, 0);
+            let mut old_ptr = self.fc + n;
+            for wp in (self.fc..self.fc + n + m).rev() {
+                if remaining_new == 0 {
+                    break; // remaining old tiles at fc..old_ptr are already in place.
+                }
+                if remaining_old > 0
+                    && rng.random_range(0..remaining_new + remaining_old) >= remaining_new
+                {
+                    old_ptr -= 1;
+                    unsafe {
+                        *self.tiles.get_unchecked_mut(wp) = *self.tiles.get_unchecked(old_ptr);
+                    }
+                    remaining_old -= 1;
+                } else {
+                    let pick = rng.random_range(0..remaining_new);
+                    unsafe {
+                        *self.tiles.get_unchecked_mut(wp) = *new_buf.get_unchecked(pick);
+                    }
+                    remaining_new -= 1;
+                    new_buf.swap(pick, remaining_new);
+                }
+            }
         }
     }
 }
@@ -141,11 +239,15 @@ impl Bag {
 impl Clone for Bag {
     #[inline(always)]
     fn clone(&self) -> Self {
-        Self(self.0.clone())
+        Self {
+            tiles: self.tiles.clone(),
+            fc: self.fc,
+        }
     }
 
     #[inline(always)]
     fn clone_from(&mut self, source: &Self) {
-        self.0.clone_from(&source.0);
+        self.tiles.clone_from(&source.tiles);
+        self.fc = source.fc;
     }
 }

--- a/src/bag.rs
+++ b/src/bag.rs
@@ -3,7 +3,7 @@
 use super::alphabet;
 use rand::prelude::*;
 
-pub struct Bag(pub Vec<u8>);
+pub struct Bag(Vec<u8>);
 
 impl Bag {
     pub fn new(alphabet: &alphabet::Alphabet) -> Bag {
@@ -37,6 +37,37 @@ impl Bag {
         for _ in 0..(rack_size - rack.len()).min(self.0.len()) {
             rack.push(self.pop().unwrap());
         }
+    }
+
+    pub fn return_tiles(&mut self, tiles: &[u8]) {
+        self.0.extend_from_slice(tiles);
+    }
+
+    pub fn return_tile(&mut self, tile: u8) {
+        self.0.push(tile);
+    }
+
+    pub fn set_from_iter<I: IntoIterator<Item = u8>>(&mut self, iter: I) {
+        self.0.clear();
+        self.0.extend(iter);
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn swap_remove_tile(&mut self, tile: u8) -> Option<()> {
+        self.0.iter().rposition(|&t| t == tile).map(|pos| {
+            self.0.swap_remove(pos);
+        })
     }
 
     // put back the tiles in random order. keep the rest of the bag in the same order.

--- a/src/bag.rs
+++ b/src/bag.rs
@@ -174,16 +174,20 @@ impl Bag {
             return;
         }
         // General case: m >= 3. Interleave with Fisher-Yates probability.
-        // Safety: wp and old_ptr stay in fc..fc+m+n = 0..tiles.len().
-        // Left-to-right: wp <= old_ptr because new_placed <= m.
-        // Right-to-left: wp >= old_ptr because new_placed <= m.
-        // pick < remaining_new <= m <= 16 = new_buf.len().
-        let mut new_buf = [0u8; 16];
-        new_buf[..m].copy_from_slice(tiles);
+        // Scratch buffer for new tiles stored in self.tiles itself.
         let mut remaining_new = m;
         let mut remaining_old = n;
         if self.fc >= m {
             // Dead space: left-to-right (wp <= old_ptr since new_placed <= m).
+            let new_base = if self.fc >= 2 * m {
+                // Scratch in dead space [0..m), disjoint from write range [fc-m..fc+n).
+                self.tiles[..m].copy_from_slice(tiles);
+                0
+            } else {
+                // fc < 2m: dead space overlaps write range. Use vec's back.
+                self.tiles.extend_from_slice(tiles);
+                self.fc + n
+            };
             self.fc -= m;
             let mut old_ptr = self.fc + m;
             for wp in self.fc..self.fc + m + n {
@@ -201,17 +205,25 @@ impl Bag {
                 } else {
                     let pick = rng.random_range(0..remaining_new);
                     unsafe {
-                        *self.tiles.get_unchecked_mut(wp) = *new_buf.get_unchecked(pick);
+                        *self.tiles.get_unchecked_mut(wp) =
+                            *self.tiles.get_unchecked(new_base + pick);
                     }
                     remaining_new -= 1;
-                    new_buf.swap(pick, remaining_new);
+                    self.tiles.swap(new_base + pick, new_base + remaining_new);
                 }
+            }
+            if new_base > 0 {
+                self.tiles.truncate(self.fc + m + n);
             }
         } else {
             // Grow: right-to-left (wp >= old_ptr since new_placed <= m).
-            self.tiles.resize(self.fc + n + m, 0);
+            // Scratch at [fc+n+m..fc+n+2m), disjoint from write range [fc..fc+n+m).
+            let final_len = self.fc + n + m;
+            self.tiles.resize(final_len + m, 0);
+            self.tiles[final_len..].copy_from_slice(tiles);
+            let new_base = final_len;
             let mut old_ptr = self.fc + n;
-            for wp in (self.fc..self.fc + n + m).rev() {
+            for wp in (self.fc..final_len).rev() {
                 if remaining_new == 0 {
                     break; // remaining old tiles at fc..old_ptr are already in place.
                 }
@@ -226,12 +238,14 @@ impl Bag {
                 } else {
                     let pick = rng.random_range(0..remaining_new);
                     unsafe {
-                        *self.tiles.get_unchecked_mut(wp) = *new_buf.get_unchecked(pick);
+                        *self.tiles.get_unchecked_mut(wp) =
+                            *self.tiles.get_unchecked(new_base + pick);
                     }
                     remaining_new -= 1;
-                    new_buf.swap(pick, remaining_new);
+                    self.tiles.swap(new_base + pick, new_base + remaining_new);
                 }
             }
+            self.tiles.truncate(final_len);
         }
     }
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -372,8 +372,10 @@ impl std::fmt::Display for GameStatePrinter<'_> {
                 board_layout: self.game_config.board_layout(),
                 board_tiles: &self.game_state.board_tiles,
             },
-            self.game_state.bag.0.len(),
-            self.game_config.alphabet().fmt_rack(&self.game_state.bag.0)
+            self.game_state.bag.len(),
+            self.game_config
+                .alphabet()
+                .fmt_rack(self.game_state.bag.as_slice())
         )?;
         let now = std::time::Instant::now();
         for (i, player) in self.game_state.players.iter().enumerate() {

--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -119,7 +119,20 @@ impl GameState {
         self.bag.shuffle(&mut rng);
         for player in self.players.iter_mut() {
             self.bag
-                .replenish(&mut player.rack, game_config.rack_size() as usize);
+                .replenish_back(&mut player.rack, game_config.rack_size() as usize);
+        }
+    }
+
+    pub fn reset_and_draw_tiles_double_ended(
+        &mut self,
+        game_config: &game_config::GameConfig,
+        mut rng: &mut dyn Rng,
+    ) {
+        self.reset();
+        self.bag.shuffle(&mut rng);
+        for (i, player) in self.players.iter_mut().enumerate() {
+            self.bag
+                .replenish(&mut player.rack, game_config.rack_size() as usize, i);
         }
     }
 
@@ -130,7 +143,7 @@ impl GameState {
             .return_tiles(&self.players[self.turn as usize].rack);
         self.players[self.turn as usize].rack.clear();
         for &tile in desired_rack {
-            match self.bag.swap_remove_tile(tile) {
+            match self.bag.remove_tile(tile) {
                 Some(()) => {
                     self.players[self.turn as usize].rack.push(tile);
                 }
@@ -142,7 +155,7 @@ impl GameState {
                                     let len = self.players[i].rack.len();
                                     self.players[i].rack.swap_remove(pos);
                                     self.players[self.turn as usize].rack.push(tile);
-                                    self.bag.replenish(&mut self.players[i].rack, len);
+                                    self.bag.replenish(&mut self.players[i].rack, len, i);
                                     break;
                                 }
                                 None => continue,
@@ -172,8 +185,11 @@ impl GameState {
                     self.zero_turns += 1;
                 } else {
                     use_tiles(&mut current_player.rack, tiles.iter().copied())?;
-                    self.bag
-                        .replenish(&mut current_player.rack, game_config.rack_size() as usize);
+                    self.bag.replenish(
+                        &mut current_player.rack,
+                        game_config.rack_size() as usize,
+                        self.turn as usize,
+                    );
                     self.bag.put_back(&mut rng, tiles);
                     self.pass_turns = 0;
                     current_player.num_exchanges += 1;
@@ -211,8 +227,11 @@ impl GameState {
                         }
                     }),
                 )?;
-                self.bag
-                    .replenish(&mut current_player.rack, game_config.rack_size() as usize);
+                self.bag.replenish(
+                    &mut current_player.rack,
+                    game_config.rack_size() as usize,
+                    self.turn as usize,
+                );
                 self.zero_turns = 0;
                 self.pass_turns = 0;
             }

--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -97,12 +97,12 @@ impl GameState {
     pub fn reset(&mut self) {
         for player in self.players.iter_mut() {
             player.score = 0;
-            self.bag.0.extend_from_slice(&player.rack);
+            self.bag.return_tiles(&player.rack);
             player.rack.clear();
             player.num_exchanges = 0;
         }
         for &tile in self.board_tiles.iter().filter(|&&tile| tile != 0) {
-            self.bag.0.push(tile & !((tile as i8) >> 7) as u8);
+            self.bag.return_tile(tile & !((tile as i8) >> 7) as u8);
         }
         self.board_tiles.iter_mut().for_each(|m| *m = 0);
         self.turn = 0;
@@ -127,13 +127,11 @@ impl GameState {
     // if desired tile is missing, final rack will be shorter.
     pub fn set_current_rack(&mut self, desired_rack: &[u8]) {
         self.bag
-            .0
-            .extend_from_slice(&self.players[self.turn as usize].rack);
+            .return_tiles(&self.players[self.turn as usize].rack);
         self.players[self.turn as usize].rack.clear();
         for &tile in desired_rack {
-            match self.bag.0.iter().rposition(|&t| t == tile) {
-                Some(pos) => {
-                    self.bag.0.swap_remove(pos);
+            match self.bag.swap_remove_tile(tile) {
+                Some(()) => {
                     self.players[self.turn as usize].rack.push(tile);
                 }
                 None => {

--- a/src/main_auto.rs
+++ b/src/main_auto.rs
@@ -17,7 +17,7 @@ fn main() -> error::Returns<()> {
             v.push((rng.get_seed(), rng.get_stream(), rng.get_word_pos()));
             bag = bag::Bag::new(&alphabet);
             bag.shuffle(&mut rng);
-            println!("Pool {}: {}", bag.0.len(), alphabet.fmt_rack(&bag.0));
+            println!("Pool {}: {}", bag.len(), alphabet.fmt_rack(bag.as_slice()));
         }
         println!("{v:?}");
         for _ in 0..40 {
@@ -31,7 +31,7 @@ fn main() -> error::Returns<()> {
             rng.set_stream(stream);
             rng.set_word_pos(word_pos);
             bag.shuffle(&mut rng);
-            println!("Pool {}: {}", bag.0.len(), alphabet.fmt_rack(&bag.0));
+            println!("Pool {}: {}", bag.len(), alphabet.fmt_rack(bag.as_slice()));
         }
         return Ok(());
     }
@@ -117,12 +117,7 @@ fn do_it<N: kwg::Node>(
             }
         }
         // put the bag
-        game_state.bag.0.clear();
-        game_state
-            .bag
-            .0
-            .reserve(available_tally.iter().map(|&x| x as usize).sum());
-        game_state.bag.0.extend(
+        game_state.bag.set_from_iter(
             (0u8..)
                 .zip(available_tally.iter())
                 .flat_map(|(tile, &count)| std::iter::repeat_n(tile, count as usize)),

--- a/src/main_auto.rs
+++ b/src/main_auto.rs
@@ -192,7 +192,7 @@ fn do_it<N: kwg::Node>(
         return Ok(());
     }
     loop {
-        game_state.reset_and_draw_tiles(game_config, &mut rng);
+        game_state.reset_and_draw_tiles_double_ended(game_config, &mut rng);
         let mut final_scores = vec![0; game_state.players.len()];
         //timers.reset_to(25 * 60 * 1000);
         timers.reset_to(15 * 1000);

--- a/src/main_json.rs
+++ b/src/main_json.rs
@@ -227,12 +227,7 @@ fn main() -> error::Returns<()> {
         .copy_from_slice(&kibitzer.board_tiles);
 
     // put the bag and shuffle it
-    game_state.bag.0.clear();
-    game_state
-        .bag
-        .0
-        .reserve(kibitzer.available_tally.iter().map(|&x| x as usize).sum());
-    game_state.bag.0.extend(
+    game_state.bag.set_from_iter(
         (0u8..)
             .zip(kibitzer.available_tally.iter())
             .flat_map(|(tile, &count)| std::iter::repeat_n(tile, count as usize)),

--- a/src/main_leave.rs
+++ b/src/main_leave.rs
@@ -866,7 +866,7 @@ fn generate_autoplay_logs<
                         game_id.push(BASE62[(num_prior_games / 62 % 62) as usize] as char);
                         game_id.push(BASE62[(num_prior_games % 62) as usize] as char);
                         let went_first = rng.random_range(0..game_config.num_players());
-                        game_state.reset_and_draw_tiles(&game_config, &mut rng);
+                        game_state.reset_and_draw_tiles_double_ended(&game_config, &mut rng);
                         game_state.turn = went_first;
                         loop {
                             num_moves += 1;
@@ -1943,7 +1943,7 @@ fn discover_playability<N: kwg::Node + Sync + Send, L: kwg::Node + Sync + Send>(
                             break;
                         }
 
-                        game_state.reset_and_draw_tiles(&game_config, &mut rng);
+                        game_state.reset_and_draw_tiles_double_ended(&game_config, &mut rng);
                         loop {
                             game_state.players[game_state.turn as usize]
                                 .rack

--- a/src/main_leave.rs
+++ b/src/main_leave.rs
@@ -876,7 +876,7 @@ fn generate_autoplay_logs<
                                 .sort_unstable();
                             let cur_rack = &game_state.current_player().rack;
 
-                            let old_bag_len = game_state.bag.0.len();
+                            let old_bag_len = game_state.bag.len();
                             if SUMMARIZE && old_bag_len > 0 {
                                 cur_rack_as_vec.clone_from(cur_rack);
                             }
@@ -1950,7 +1950,7 @@ fn discover_playability<N: kwg::Node + Sync + Send, L: kwg::Node + Sync + Send>(
                                 .sort_unstable();
                             let cur_rack = &game_state.current_player().rack;
 
-                            let old_bag_len = game_state.bag.0.len();
+                            let old_bag_len = game_state.bag.len();
 
                             let board_snapshot = &movegen::BoardSnapshot {
                                 board_tiles: &game_state.board_tiles,

--- a/src/main_simmer.rs
+++ b/src/main_simmer.rs
@@ -245,10 +245,10 @@ fn main() -> error::Returns<()> {
             .zip(available_tally.iter())
             .flat_map(|(tile, &count)| std::iter::repeat_n(tile, count as usize)),
     );
-    for player in game_state.players.iter_mut() {
+    for (i, player) in game_state.players.iter_mut().enumerate() {
         game_state
             .bag
-            .replenish(&mut player.rack, game_config.rack_size() as usize);
+            .replenish(&mut player.rack, game_config.rack_size() as usize, i);
     }
     display::print_game_state(&game_config, &game_state, None);
 

--- a/src/main_simmer.rs
+++ b/src/main_simmer.rs
@@ -240,8 +240,7 @@ fn main() -> error::Returns<()> {
     }
     game_state.board_tiles[..].clone_from_slice(&board_tiles);
     game_state.set_current_rack(&question.rack);
-    game_state.bag.0.clear();
-    game_state.bag.0.extend(
+    game_state.bag.set_from_iter(
         (0u8..)
             .zip(available_tally.iter())
             .flat_map(|(tile, &count)| std::iter::repeat_n(tile, count as usize)),

--- a/src/play_scorer.rs
+++ b/src/play_scorer.rs
@@ -39,7 +39,7 @@ impl PlayScorer {
             movegen::Play::Exchange { tiles } => {
                 if tiles.is_empty() {
                     return Ok(None);
-                } else if game_state.bag.0.len() < game_config.exchange_tile_limit() as usize {
+                } else if game_state.bag.len() < game_config.exchange_tile_limit() as usize {
                     return_error!("not enough tiles to allow exchanges".into());
                 }
 
@@ -467,7 +467,7 @@ impl PlayScorer {
         };
 
         let mut recounted_equity = recounted_score as f32;
-        if game_state.bag.0.is_empty() {
+        if game_state.bag.is_empty() {
             // empty bag, do not add leave.
             if self.rack_tally.iter().any(|&count| count != 0) {
                 let kept_tiles_worth = (0u8..)

--- a/src/simmer.rs
+++ b/src/simmer.rs
@@ -128,9 +128,11 @@ impl Simmer {
         });
         for (i, player) in self.initial_game_state.players.iter_mut().enumerate() {
             if i != initial_turn {
-                self.initial_game_state
-                    .bag
-                    .replenish(&mut player.rack, self.final_scores[i] as usize);
+                self.initial_game_state.bag.replenish(
+                    &mut player.rack,
+                    self.final_scores[i] as usize,
+                    i,
+                );
             }
         }
     }

--- a/src/simmer.rs
+++ b/src/simmer.rs
@@ -89,7 +89,7 @@ impl Simmer {
                 .unwrap_or(0);
         self.num_sim_plies = num_sim_plies;
         self.num_tiles_that_matter = num_sim_plies * game_config.rack_size() as usize;
-        let mut num_unseen_tiles = self.initial_game_state.bag.0.len();
+        let mut num_unseen_tiles = self.initial_game_state.bag.len();
         let initial_turn = self.initial_game_state.turn as usize;
         for (i, player) in self.initial_game_state.players.iter_mut().enumerate() {
             if i != initial_turn {
@@ -117,10 +117,7 @@ impl Simmer {
         for (i, player) in self.initial_game_state.players.iter_mut().enumerate() {
             if i != initial_turn {
                 self.final_scores[i] = player.rack.len() as i32;
-                self.initial_game_state
-                    .bag
-                    .0
-                    .extend_from_slice(&player.rack);
+                self.initial_game_state.bag.return_tiles(&player.rack);
                 player.rack.clear();
             }
         }
@@ -243,7 +240,7 @@ impl Simmer {
         } else {
             // handwavily: assume spread of +/- (30 + num_unseen_tiles) should be 90%/10% (-Andy Kurnia)
             // (to adjust these, adjust the 30.0 and 0.9 consts below)
-            let num_unseen_tiles = self.game_state.bag.0.len()
+            let num_unseen_tiles = self.game_state.bag.len()
                 + self
                     .game_state
                     .players


### PR DESCRIPTION
## Summary
- **Commit 1**: Encapsulate Bag internals — make field private, add semantic methods (`return_tiles`, `return_tile`, `set_from_iter`, `as_slice`, `len`, `is_empty`, `remove_tile`)
- **Commit 2**: Double-ended bag drawing — even players draw from back, odd from front. Bag uses front cursor (`fc`) with `tiles[0..fc]` as dead space. Optimized `put_back` with special cases for m=1 (1 random call), m=2 (2 random calls, swap doubles as coin flip), and general m>=3 (interleave with early break). Order-preserving `remove_tile`.
- **Commit 3**: `put_back` uses `self.tiles` as scratch buffer instead of fixed `[0u8; 16]`, removing the m<=16 assumption. When fc >= 2m, scratch lives in dead space (zero allocation). Otherwise, scratch is appended to the vec's back.

## Why
Prepares infrastructure for game pairs (playing each seed twice with different initial players).

## Notes
- `main_endgame.rs` unchanged — still uses `reset_and_draw_tiles` (back-only)
- Callers that want double-ended drawing use `reset_and_draw_tiles_double_ended`
- No `unsafe` except in the general (m>=3) `put_back` loop, with safety proof in comments
- Redo of PR #9/#11 (attribution fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>