### PR TITLE
play each seed as a game pair with swapped starting player

### DIFF
--- a/src/main_auto.rs
+++ b/src/main_auto.rs
@@ -196,291 +196,298 @@ fn do_it<N: kwg::Node>(
         game_state.reset_and_draw_tiles_double_ended(game_config, &mut rng);
         saved_game_state.clone_from(&game_state);
         for went_first in 0..2u8 {
-        if went_first > 0 {
-            game_state.clone_from(&saved_game_state);
-        }
-        game_state.turn = went_first;
-        let mut final_scores = vec![0; game_state.players.len()];
-        //timers.reset_to(25 * 60 * 1000);
-        timers.reset_to(15 * 1000);
+            if went_first > 0 {
+                game_state.clone_from(&saved_game_state);
+            }
+            game_state.turn = went_first;
+            let mut final_scores = vec![0; game_state.players.len()];
+            //timers.reset_to(25 * 60 * 1000);
+            timers.reset_to(15 * 1000);
 
-        loop {
-            timers.set_turn(game_state.turn as i8);
-            display::print_game_state(game_config, &game_state, Some(&timers));
+            loop {
+                timers.set_turn(game_state.turn as i8);
+                display::print_game_state(game_config, &game_state, Some(&timers));
 
-            if false {
-                let fen_str = format!(
-                    "{}",
-                    display::BoardFenner::new(
-                        game_config.alphabet(),
-                        game_config.board_layout(),
-                        &game_state.board_tiles,
-                    )
-                );
-                println!("{fen_str}");
-                let parsed_fen = fen_parser.parse(&fen_str)?;
-                if parsed_fen != &game_state.board_tiles[..] {
+                if false {
+                    let fen_str = format!(
+                        "{}",
+                        display::BoardFenner::new(
+                            game_config.alphabet(),
+                            game_config.board_layout(),
+                            &game_state.board_tiles,
+                        )
+                    );
+                    println!("{fen_str}");
+                    let parsed_fen = fen_parser.parse(&fen_str)?;
+                    if parsed_fen != &game_state.board_tiles[..] {
+                        println!(
+                            "{} parses into {:?} (expecting {:?})",
+                            fen_str, parsed_fen, game_state.board_tiles
+                        );
+                    }
+                }
+
+                let filtered_movegen = if game_state.turn == 0 {
+                    &mut filtered_movegen_0
+                } else {
+                    &mut filtered_movegen_1
+                };
+                if let move_filter::GenMoves::Tilt { tilt, bot_level } = filtered_movegen {
+                    tilt.tilt_by_rng(&mut rng, *bot_level);
                     println!(
-                        "{} parses into {:?} (expecting {:?})",
-                        fen_str, parsed_fen, game_state.board_tiles
+                        "Effective tilt: tilt factor = {}, leave scale = {}",
+                        tilt.tilt_factor, tilt.leave_scale
                     );
                 }
-            }
 
-            let filtered_movegen = if game_state.turn == 0 {
-                &mut filtered_movegen_0
-            } else {
-                &mut filtered_movegen_1
-            };
-            if let move_filter::GenMoves::Tilt { tilt, bot_level } = filtered_movegen {
-                tilt.tilt_by_rng(&mut rng, *bot_level);
-                println!(
-                    "Effective tilt: tilt factor = {}, leave scale = {}",
-                    tilt.tilt_factor, tilt.leave_scale
-                );
-            }
+                let move_picker = if game_state.turn == 0 {
+                    &mut move_picker_0
+                } else {
+                    &mut move_picker_1
+                };
 
-            let move_picker = if game_state.turn == 0 {
-                &mut move_picker_0
-            } else {
-                &mut move_picker_1
-            };
+                let board_snapshot = &movegen::BoardSnapshot {
+                    board_tiles: &game_state.board_tiles,
+                    game_config,
+                    kwg,
+                    klv,
+                };
 
-            let board_snapshot = &movegen::BoardSnapshot {
-                board_tiles: &game_state.board_tiles,
-                game_config,
-                kwg,
-                klv,
-            };
+                if false {
+                    move_generator.gen_moves_unfiltered(&movegen::GenMovesParams {
+                        board_snapshot,
+                        rack: &game_state.current_player().rack,
+                        max_gen: usize::MAX,
+                        num_exchanges_by_this_player: game_state.current_player().num_exchanges,
+                        always_include_pass: false,
+                    });
+                    // test word prune, only for classic.
+                    let plays2;
+                    let plays = if match &board_snapshot.game_config.game_rules() {
+                        game_config::GameRules::Classic => true,
+                        game_config::GameRules::Jumbled => false,
+                    } {
+                        let plays1 = move_generator.plays.clone();
+                        // these always allocate for now.
+                        let mut set_of_words = fash::MyHashSet::<bites::Bites>::default();
+                        move_generator.gen_remaining_words(board_snapshot, |word: &[u8]| {
+                            set_of_words.insert(word.into());
+                        });
+                        println!("word_prune: {} words", set_of_words.len());
+                        let mut vec_of_words = set_of_words.into_iter().collect::<Vec<_>>();
+                        vec_of_words.sort_unstable();
+                        let smaller_kwg_bytes = build::build(
+                            build::BuildContent::Gaddawg,
+                            build::BuildLayout::Wolges,
+                            &vec_of_words.into_boxed_slice(),
+                        )?;
+                        println!("word_prune: {} bytes kwg", smaller_kwg_bytes.len());
+                        let smaller_kwg = kwg::Kwg::<N>::from_bytes_alloc(&smaller_kwg_bytes);
+                        move_generator.reset_for_another_kwg();
+                        move_generator.gen_moves_unfiltered(&movegen::GenMovesParams {
+                            board_snapshot: &movegen::BoardSnapshot {
+                                kwg: &smaller_kwg,
+                                ..*board_snapshot
+                            },
+                            rack: &game_state.current_player().rack,
+                            max_gen: usize::MAX,
+                            num_exchanges_by_this_player: game_state.current_player().num_exchanges,
+                            always_include_pass: false,
+                        });
+                        plays2 = move_generator.plays.clone();
+                        move_generator.reset_for_another_kwg();
+                        move_generator.gen_moves_unfiltered(&movegen::GenMovesParams {
+                            board_snapshot,
+                            rack: &game_state.current_player().rack,
+                            max_gen: usize::MAX,
+                            num_exchanges_by_this_player: game_state.current_player().num_exchanges,
+                            always_include_pass: false,
+                        });
+                        if plays1 != move_generator.plays {
+                            panic!("movegen was confused");
+                        }
+                        if plays1 != plays2 {
+                            panic!("movegen cannot work with smaller kwg");
+                        }
+                        &plays2
+                    } else {
+                        &move_generator.plays
+                    };
+                    println!("{} moves found...", plays.len());
+                    for play in plays.iter() {
+                        println!("{} {}", play.equity, play.play.fmt(board_snapshot));
+                    }
+                }
 
-            if false {
-                move_generator.gen_moves_unfiltered(&movegen::GenMovesParams {
-                    board_snapshot,
-                    rack: &game_state.current_player().rack,
-                    max_gen: usize::MAX,
-                    num_exchanges_by_this_player: game_state.current_player().num_exchanges,
-                    always_include_pass: false,
-                });
-                // test word prune, only for classic.
-                let plays2;
-                let plays = if match &board_snapshot.game_config.game_rules() {
-                    game_config::GameRules::Classic => true,
+                // stress-test scoring algorithm
+                if match &board_snapshot.game_config.game_rules() {
+                    game_config::GameRules::Classic => false,
                     game_config::GameRules::Jumbled => false,
                 } {
-                    let plays1 = move_generator.plays.clone();
-                    // these always allocate for now.
-                    let mut set_of_words = fash::MyHashSet::<bites::Bites>::default();
-                    move_generator.gen_remaining_words(board_snapshot, |word: &[u8]| {
-                        set_of_words.insert(word.into());
-                    });
-                    println!("word_prune: {} words", set_of_words.len());
-                    let mut vec_of_words = set_of_words.into_iter().collect::<Vec<_>>();
-                    vec_of_words.sort_unstable();
-                    let smaller_kwg_bytes = build::build(
-                        build::BuildContent::Gaddawg,
-                        build::BuildLayout::Wolges,
-                        &vec_of_words.into_boxed_slice(),
-                    )?;
-                    println!("word_prune: {} bytes kwg", smaller_kwg_bytes.len());
-                    let smaller_kwg = kwg::Kwg::<N>::from_bytes_alloc(&smaller_kwg_bytes);
-                    move_generator.reset_for_another_kwg();
-                    move_generator.gen_moves_unfiltered(&movegen::GenMovesParams {
-                        board_snapshot: &movegen::BoardSnapshot {
-                            kwg: &smaller_kwg,
-                            ..*board_snapshot
+                    let leave_scale =
+                        if let move_filter::GenMoves::Tilt { tilt, .. } = filtered_movegen {
+                            tilt.leave_scale
+                        } else {
+                            1.0
+                        };
+                    move_generator.gen_moves_filtered(
+                        &movegen::GenMovesParams {
+                            board_snapshot,
+                            rack: &game_state.current_player().rack,
+                            max_gen: usize::MAX,
+                            num_exchanges_by_this_player: game_state.current_player().num_exchanges,
+                            always_include_pass: true,
                         },
-                        rack: &game_state.current_player().rack,
-                        max_gen: usize::MAX,
-                        num_exchanges_by_this_player: game_state.current_player().num_exchanges,
-                        always_include_pass: false,
-                    });
-                    plays2 = move_generator.plays.clone();
-                    move_generator.reset_for_another_kwg();
-                    move_generator.gen_moves_unfiltered(&movegen::GenMovesParams {
-                        board_snapshot,
-                        rack: &game_state.current_player().rack,
-                        max_gen: usize::MAX,
-                        num_exchanges_by_this_player: game_state.current_player().num_exchanges,
-                        always_include_pass: false,
-                    });
-                    if plays1 != move_generator.plays {
-                        panic!("movegen was confused");
-                    }
-                    if plays1 != plays2 {
-                        panic!("movegen cannot work with smaller kwg");
-                    }
-                    &plays2
-                } else {
-                    &move_generator.plays
-                };
-                println!("{} moves found...", plays.len());
-                for play in plays.iter() {
-                    println!("{} {}", play.equity, play.play.fmt(board_snapshot));
-                }
-            }
-
-            // stress-test scoring algorithm
-            if match &board_snapshot.game_config.game_rules() {
-                game_config::GameRules::Classic => false,
-                game_config::GameRules::Jumbled => false,
-            } {
-                let leave_scale = if let move_filter::GenMoves::Tilt { tilt, .. } = filtered_movegen
-                {
-                    tilt.leave_scale
-                } else {
-                    1.0
-                };
-                move_generator.gen_moves_filtered(
-                    &movegen::GenMovesParams {
-                        board_snapshot,
-                        rack: &game_state.current_player().rack,
-                        max_gen: usize::MAX,
-                        num_exchanges_by_this_player: game_state.current_player().num_exchanges,
-                        always_include_pass: true,
-                    },
-                    |_down: bool, _lane: i8, _idx: i8, _word: &[u8], _score: i32| true,
-                    |leave_value: f32| leave_scale * leave_value,
-                    |_equity: f32, _play: &movegen::Play| true,
-                );
-                let plays = &mut move_generator.plays;
-                println!("{} moves found...", plays.len());
-                let mut issues = 0;
-                let mut ps = play_scorer::PlayScorer::new();
-                for play in plays.iter() {
-                    match ps.validate_play(board_snapshot, &game_state, &play.play) {
-                        Err(err) => {
-                            issues += 1;
-                            println!("{} is not valid, {}!", play.play.fmt(board_snapshot), err);
-                        }
-                        Ok(adjusted_play) => {
-                            if let Some(canonical_play) = adjusted_play {
+                        |_down: bool, _lane: i8, _idx: i8, _word: &[u8], _score: i32| true,
+                        |leave_value: f32| leave_scale * leave_value,
+                        |_equity: f32, _play: &movegen::Play| true,
+                    );
+                    let plays = &mut move_generator.plays;
+                    println!("{} moves found...", plays.len());
+                    let mut issues = 0;
+                    let mut ps = play_scorer::PlayScorer::new();
+                    for play in plays.iter() {
+                        match ps.validate_play(board_snapshot, &game_state, &play.play) {
+                            Err(err) => {
                                 issues += 1;
                                 println!(
-                                    "{} is valid, but reformats into {}!",
+                                    "{} is not valid, {}!",
                                     play.play.fmt(board_snapshot),
-                                    canonical_play.fmt(board_snapshot)
+                                    err
                                 );
                             }
-                            let movegen_score = match &play.play {
-                                movegen::Play::Exchange { .. } => 0,
-                                movegen::Play::Place { score, .. } => *score,
-                            };
-                            let recounted_score = ps.compute_score(board_snapshot, &play.play);
-                            if movegen_score != recounted_score {
-                                issues += 1;
-                                println!(
-                                    "{} should score {} instead of {}!",
-                                    play.play.fmt(board_snapshot),
-                                    recounted_score,
-                                    movegen_score
-                                );
-                            } else {
-                                let recounted_equity = ps.compute_equity(
-                                    board_snapshot,
-                                    &game_state,
-                                    &play.play,
-                                    leave_scale,
-                                    recounted_score,
-                                );
-                                // If leave_scale is negative these may be 0.0 and -0.0.
-                                if play.equity.to_le_bytes() != recounted_equity.to_le_bytes()
-                                    && !(play.equity == 0.0 && recounted_equity == 0.0)
-                                {
+                            Ok(adjusted_play) => {
+                                if let Some(canonical_play) = adjusted_play {
                                     issues += 1;
                                     println!(
-                                        "{} should have equity {} instead of {}!",
+                                        "{} is valid, but reformats into {}!",
                                         play.play.fmt(board_snapshot),
-                                        recounted_equity,
-                                        play.equity
+                                        canonical_play.fmt(board_snapshot)
+                                    );
+                                }
+                                let movegen_score = match &play.play {
+                                    movegen::Play::Exchange { .. } => 0,
+                                    movegen::Play::Place { score, .. } => *score,
+                                };
+                                let recounted_score = ps.compute_score(board_snapshot, &play.play);
+                                if movegen_score != recounted_score {
+                                    issues += 1;
+                                    println!(
+                                        "{} should score {} instead of {}!",
+                                        play.play.fmt(board_snapshot),
+                                        recounted_score,
+                                        movegen_score
+                                    );
+                                } else {
+                                    let recounted_equity = ps.compute_equity(
+                                        board_snapshot,
+                                        &game_state,
+                                        &play.play,
+                                        leave_scale,
+                                        recounted_score,
+                                    );
+                                    // If leave_scale is negative these may be 0.0 and -0.0.
+                                    if play.equity.to_le_bytes() != recounted_equity.to_le_bytes()
+                                        && !(play.equity == 0.0 && recounted_equity == 0.0)
+                                    {
+                                        issues += 1;
+                                        println!(
+                                            "{} should have equity {} instead of {}!",
+                                            play.play.fmt(board_snapshot),
+                                            recounted_equity,
+                                            play.equity
+                                        );
+                                    }
+                                }
+                                if !ps.words_are_valid(board_snapshot, &play.play) {
+                                    issues += 1;
+                                    println!(
+                                        "{} forms invalid words!",
+                                        play.play.fmt(board_snapshot)
                                     );
                                 }
                             }
-                            if !ps.words_are_valid(board_snapshot, &play.play) {
-                                issues += 1;
-                                println!("{} forms invalid words!", play.play.fmt(board_snapshot));
-                            }
                         }
                     }
+                    assert_eq!(issues, 0);
                 }
-                assert_eq!(issues, 0);
+
+                if false {
+                    // not required for now.
+                    move_generator.reset_for_another_kwg();
+                }
+                move_picker.pick_a_move(
+                    filtered_movegen,
+                    &mut move_generator,
+                    board_snapshot,
+                    &game_state,
+                    &game_state.current_player().rack,
+                );
+                let plays = &mut move_generator.plays;
+                let play = &plays[0].play; // assume at least there's always Pass
+                println!("Playing: {}", play.fmt(board_snapshot));
+
+                game_state.play(game_config, &mut rng, play)?;
+
+                match game_state.check_game_ended(game_config, &mut final_scores) {
+                    game_state::CheckGameEnded::PlayedOut => {
+                        println!("Player {} went out", game_state.turn + 1);
+                        break;
+                    }
+                    game_state::CheckGameEnded::ZeroScores => {
+                        println!(
+                            "Player {} ended game by making yet another zero score",
+                            game_state.turn + 1
+                        );
+                        break;
+                    }
+                    game_state::CheckGameEnded::NotEnded => {}
+                }
+                game_state.next_turn();
+            }
+            timers.set_turn(-1);
+
+            display::print_game_state(game_config, &game_state, Some(&timers));
+            println!("Final scores: {final_scores:?}");
+            let mut has_time_adjustment = false;
+            for (i, &clock_ms) in timers.clocks_ms.iter().enumerate() {
+                let adjustment = game_config.time_adjustment(clock_ms);
+                if adjustment != 0 {
+                    println!("Player {} adjustment {}", i + 1, adjustment);
+                    final_scores[i] += adjustment as i32;
+                    has_time_adjustment = true;
+                }
+            }
+            if has_time_adjustment {
+                println!("Really final scores: {final_scores:?}");
             }
 
-            if false {
-                // not required for now.
-                move_generator.reset_for_another_kwg();
-            }
-            move_picker.pick_a_move(
-                filtered_movegen,
-                &mut move_generator,
-                board_snapshot,
-                &game_state,
-                &game_state.current_player().rack,
+            let fs0 = final_scores[0];
+            let fs1 = final_scores[1];
+            let spr = fs0 - fs1;
+            let p0dw = spr.signum() + 1; // double win (2 = win, 1 = draw/tie, 0 = loss)
+            score_stats_0.update(fs0.into());
+            score_stats_1.update(fs1.into());
+            spread_stats_0.update(spr.into());
+            win_stats_0.update(p0dw as f64 * 50.0);
+            loss_draw_win[p0dw as usize] += 1;
+
+            println!(
+                "Stats: {final_scores:?} n={} ({}-{}-{}) p0={:.3} (sd={:.3}) p1={:.3} (sd={:.3}) p0-p1={:.3} (sd={:.3}) p0w={:.3} (sd={:.3})",
+                loss_draw_win[0] + loss_draw_win[1] + loss_draw_win[2],
+                loss_draw_win[2],
+                loss_draw_win[0],
+                loss_draw_win[1],
+                score_stats_0.mean(),
+                score_stats_0.standard_deviation(),
+                score_stats_1.mean(),
+                score_stats_1.standard_deviation(),
+                spread_stats_0.mean(),
+                spread_stats_0.standard_deviation(),
+                win_stats_0.mean(),
+                win_stats_0.standard_deviation(),
             );
-            let plays = &mut move_generator.plays;
-            let play = &plays[0].play; // assume at least there's always Pass
-            println!("Playing: {}", play.fmt(board_snapshot));
-
-            game_state.play(game_config, &mut rng, play)?;
-
-            match game_state.check_game_ended(game_config, &mut final_scores) {
-                game_state::CheckGameEnded::PlayedOut => {
-                    println!("Player {} went out", game_state.turn + 1);
-                    break;
-                }
-                game_state::CheckGameEnded::ZeroScores => {
-                    println!(
-                        "Player {} ended game by making yet another zero score",
-                        game_state.turn + 1
-                    );
-                    break;
-                }
-                game_state::CheckGameEnded::NotEnded => {}
-            }
-            game_state.next_turn();
-        }
-        timers.set_turn(-1);
-
-        display::print_game_state(game_config, &game_state, Some(&timers));
-        println!("Final scores: {final_scores:?}");
-        let mut has_time_adjustment = false;
-        for (i, &clock_ms) in timers.clocks_ms.iter().enumerate() {
-            let adjustment = game_config.time_adjustment(clock_ms);
-            if adjustment != 0 {
-                println!("Player {} adjustment {}", i + 1, adjustment);
-                final_scores[i] += adjustment as i32;
-                has_time_adjustment = true;
-            }
-        }
-        if has_time_adjustment {
-            println!("Really final scores: {final_scores:?}");
-        }
-
-        let fs0 = final_scores[0];
-        let fs1 = final_scores[1];
-        let spr = fs0 - fs1;
-        let p0dw = spr.signum() + 1; // double win (2 = win, 1 = draw/tie, 0 = loss)
-        score_stats_0.update(fs0.into());
-        score_stats_1.update(fs1.into());
-        spread_stats_0.update(spr.into());
-        win_stats_0.update(p0dw as f64 * 50.0);
-        loss_draw_win[p0dw as usize] += 1;
-
-        println!(
-            "Stats: {final_scores:?} n={} ({}-{}-{}) p0={:.3} (sd={:.3}) p1={:.3} (sd={:.3}) p0-p1={:.3} (sd={:.3}) p0w={:.3} (sd={:.3})",
-            loss_draw_win[0] + loss_draw_win[1] + loss_draw_win[2],
-            loss_draw_win[2],
-            loss_draw_win[0],
-            loss_draw_win[1],
-            score_stats_0.mean(),
-            score_stats_0.standard_deviation(),
-            score_stats_1.mean(),
-            score_stats_1.standard_deviation(),
-            spread_stats_0.mean(),
-            spread_stats_0.standard_deviation(),
-            win_stats_0.mean(),
-            win_stats_0.standard_deviation(),
-        );
-    } // for went_first
+        } // for went_first
     } // temp loop
 
     //Ok(())

--- a/src/main_auto.rs
+++ b/src/main_auto.rs
@@ -191,8 +191,15 @@ fn do_it<N: kwg::Node>(
         }
         return Ok(());
     }
+    let mut saved_game_state = game_state.clone();
     loop {
         game_state.reset_and_draw_tiles_double_ended(game_config, &mut rng);
+        saved_game_state.clone_from(&game_state);
+        for went_first in 0..2u8 {
+        if went_first > 0 {
+            game_state.clone_from(&saved_game_state);
+        }
+        game_state.turn = went_first;
         let mut final_scores = vec![0; game_state.players.len()];
         //timers.reset_to(25 * 60 * 1000);
         timers.reset_to(15 * 1000);
@@ -473,6 +480,7 @@ fn do_it<N: kwg::Node>(
             win_stats_0.mean(),
             win_stats_0.standard_deviation(),
         );
+    } // for went_first
     } // temp loop
 
     //Ok(())


### PR DESCRIPTION
## Summary

- Shuffle and draw tiles once per seed, then play two games with swapped starting player
- Save game state after the initial draw; restore it for the second game so both use the identical bag
- Each iteration now contributes two games to the stats, reducing variance from first-player advantage and tile draw order

## Test plan

- [x] Verified `Pool 86` lines match between paired games
- [x] cargo fmt, clippy, build pass