### PR TITLE
use bitmask AND for cross set computation, skip dead anchors

### DIFF
--- a/src/kwg.rs
+++ b/src/kwg.rs
@@ -83,6 +83,12 @@ pub fn read_le_u32(bytes: &[u8], p: usize) -> u32 {
 
 pub struct Kwg<N: Node>(pub Box<[N]>);
 
+// Precomputed bitmask of child tiles for each sibling group position.
+// letter_bits[i] = bitmask of tiles from node i through the end of its
+// sibling group. Bit 0 = separator/blank, bits 1-26 = tiles A-Z.
+#[derive(Clone)]
+pub struct LetterBits(pub Box<[u64]>);
+
 // kwg::Node22
 pub static EMPTY_KWG_BYTES: &[u8] = b"\x00\x00\x40\x00\x00\x00\x40\x00";
 
@@ -159,6 +165,26 @@ impl<N: Node> Kwg<N> {
             self.count_words_at(&mut word_counts, p as i32);
         }
         word_counts.into_boxed_slice()
+    }
+
+    // Precompute letter_bits for every sibling group position.
+    // Scan right-to-left: accumulate tile bits, reset at each is_end node.
+    pub fn compute_letter_bits(&self) -> LetterBits {
+        let len = self.0.len();
+        let mut bits = vec![0u64; len];
+        let mut acc = 0u64;
+        for i in (0..len).rev() {
+            let node = self.0[i];
+            // Reset BEFORE accumulating: is_end marks the last sibling
+            // (rightmost), and the scan goes right-to-left. Resetting
+            // before ensures this node's bits start a fresh group.
+            if node.is_end() {
+                acc = 0;
+            }
+            acc |= 1u64 << node.tile();
+            bits[i] = acc;
+        }
+        LetterBits(bits.into_boxed_slice())
     }
 
     pub fn count_dawg_words_alloc(&self) -> Box<[u32]> {

--- a/src/kwg.rs
+++ b/src/kwg.rs
@@ -83,11 +83,14 @@ pub fn read_le_u32(bytes: &[u8], p: usize) -> u32 {
 
 pub struct Kwg<N: Node>(pub Box<[N]>);
 
-// Precomputed bitmask of child tiles for each sibling group position.
-// letter_bits[i] = bitmask of tiles from node i through the end of its
-// sibling group. Bit 0 = separator/blank, bits 1-26 = tiles A-Z.
+// Precomputed bitmasks of child tiles for each sibling group position.
+// letter_bits[i] = bitmask of ALL tiles from node i through end of group.
+// accepting_bits[i] = bitmask of only ACCEPTING tiles (complete a word).
 #[derive(Clone)]
-pub struct LetterBits(pub Box<[u64]>);
+pub struct LetterBits {
+    pub letter_bits: Box<[u64]>,
+    pub accepting_bits: Box<[u64]>,
+}
 
 // kwg::Node22
 pub static EMPTY_KWG_BYTES: &[u8] = b"\x00\x00\x40\x00\x00\x00\x40\x00";
@@ -167,24 +170,33 @@ impl<N: Node> Kwg<N> {
         word_counts.into_boxed_slice()
     }
 
-    // Precompute letter_bits for every sibling group position.
+    // Precompute letter_bits and accepting_bits for every sibling group position.
     // Scan right-to-left: accumulate tile bits, reset at each is_end node.
     pub fn compute_letter_bits(&self) -> LetterBits {
         let len = self.0.len();
-        let mut bits = vec![0u64; len];
-        let mut acc = 0u64;
+        let mut letter_bits = vec![0u64; len];
+        let mut accepting_bits = vec![0u64; len];
+        let mut all_acc = 0u64;
+        let mut accept_acc = 0u64;
         for i in (0..len).rev() {
             let node = self.0[i];
             // Reset BEFORE accumulating: is_end marks the last sibling
             // (rightmost), and the scan goes right-to-left. Resetting
             // before ensures this node's bits start a fresh group.
             if node.is_end() {
-                acc = 0;
+                all_acc = 0;
+                accept_acc = 0;
             }
-            acc |= 1u64 << node.tile();
-            bits[i] = acc;
+            let tile_bit = 1u64 << node.tile();
+            all_acc |= tile_bit;
+            accept_acc |= tile_bit & (-i64::from(node.accepts())) as u64;
+            letter_bits[i] = all_acc;
+            accepting_bits[i] = accept_acc;
         }
-        LetterBits(bits.into_boxed_slice())
+        LetterBits {
+            letter_bits: letter_bits.into_boxed_slice(),
+            accepting_bits: accepting_bits.into_boxed_slice(),
+        }
     }
 
     pub fn count_dawg_words_alloc(&self) -> Box<[u32]> {

--- a/src/movegen.rs
+++ b/src/movegen.rs
@@ -1421,17 +1421,18 @@ fn gen_place_placements<'a, PossibleStripPlacementCallbackType: FnMut(i8, i8, i8
         want_raw: bool,
         mut possible_strip_placement_callback: PossibleStripPlacementCallbackType,
     ) {
-        if want_raw {
+        if env.params.left_extension_strip[env.anchor as usize] == 0
+            && env.params.right_extension_strip[env.anchor as usize] == 0
+        {
+            // Dead anchor: no tile can extend in either direction.
+        } else if want_raw {
             possible_strip_placement_callback(
                 env.anchor,
                 env.leftmost,
                 env.rightmost,
                 f32::INFINITY,
             );
-        } else if (env.params.left_extension_strip[env.anchor as usize]
-            | env.params.right_extension_strip[env.anchor as usize])
-            != 0
-        {
+        } else {
             env.best_possible_equity = f32::NEG_INFINITY;
             shadow_play_left(
                 env,

--- a/src/movegen.rs
+++ b/src/movegen.rs
@@ -95,6 +95,7 @@ struct WorkingBuffer {
     used_tile_scores_shadowr: Vec<i8>, // rack.len() (for shadow_play_right)
     rack_tally_shadowl: Box<[u8]>, // 27 for ?A-Z (for shadow_play_left)
     rack_tally_shadowr: Box<[u8]>, // 27 for ?A-Z (for shadow_play_right)
+    kwg_letter_bits: Option<kwg::LetterBits>, // precomputed child tile bitmasks, lazily initialized
 }
 
 impl Clone for WorkingBuffer {
@@ -165,6 +166,7 @@ impl Clone for WorkingBuffer {
             used_tile_scores_shadowr: self.used_tile_scores_shadowr.clone(),
             rack_tally_shadowl: self.rack_tally_shadowl.clone(),
             rack_tally_shadowr: self.rack_tally_shadowr.clone(),
+            kwg_letter_bits: self.kwg_letter_bits.clone(),
         }
     }
 
@@ -256,6 +258,7 @@ impl Clone for WorkingBuffer {
             .clone_from(&source.rack_tally_shadowl);
         self.rack_tally_shadowr
             .clone_from(&source.rack_tally_shadowr);
+        self.kwg_letter_bits.clone_from(&source.kwg_letter_bits);
     }
 }
 
@@ -363,6 +366,7 @@ impl WorkingBuffer {
             used_tile_scores_shadowr: Vec::new(),
             rack_tally_shadowl: vec![0u8; game_config.alphabet().len() as usize].into_boxed_slice(),
             rack_tally_shadowr: vec![0u8; game_config.alphabet().len() as usize].into_boxed_slice(),
+            kwg_letter_bits: None,
         }
     }
 
@@ -596,6 +600,7 @@ impl WorkingBuffer {
         self.right_extension_set_for_across_plays.fill(!0u64);
         self.left_extension_set_for_down_plays.fill(!0u64);
         self.right_extension_set_for_down_plays.fill(!0u64);
+        self.kwg_letter_bits = None;
         self.accepts_alpha_cache.fill(([0u8; 64], false));
     }
 }
@@ -997,40 +1002,36 @@ fn gen_cross_set<'a, N: kwg::Node, L: kwg::Node>(
 // Right extension set at position j: which tiles can extend rightward into j,
 // given the board tiles to the left of j.
 // Non-adjacent empty squares get !0u64 (all bits, no constraint).
+// Look up child tile bitmask from precomputed letter_bits table.
+// Excludes separator (bit 0), then adds blank bit if non-empty.
+#[inline(always)]
+fn extension_bits_from_letter_bits<N: kwg::Node>(
+    kwg: &kwg::Kwg<N>,
+    letter_bits: &kwg::LetterBits,
+    p: i32,
+) -> u64 {
+    if p <= 0 {
+        return 0;
+    }
+    let arc = kwg[p].arc_index();
+    if arc <= 0 {
+        return 0;
+    }
+    let bits = letter_bits.0[arc as usize] & !1;
+    bits | (bits != 0) as u64
+}
+
 fn gen_extension_sets<N: kwg::Node>(
     kwg: &kwg::Kwg<N>,
+    letter_bits: &kwg::LetterBits,
     cross_set_buffer: &[CrossSetComputation],
     left_extension_sets: &mut [u64],
     right_extension_sets: &mut [u64],
 ) {
     let len = cross_set_buffer.len();
 
-    // Collect extension set bits from a GADDAG node's children.
-    // Excludes separator (bit 0), then adds blank bit if non-empty.
-    let collect_bits = |kwg: &kwg::Kwg<N>, p: i32| -> u64 {
-        if p <= 0 {
-            return 0;
-        }
-        let mut bits = 0u64;
-        let mut q = kwg[p].arc_index();
-        if q > 0 {
-            loop {
-                let node = kwg[q];
-                bits |= 1u64 << node.tile();
-                if node.is_end() {
-                    break;
-                }
-                q += 1;
-            }
-        }
-        let bits = bits & !1;
-        bits | (bits != 0) as u64
-    };
-
     // Read GADDAG state (p) from cross_set_buffer instead of recomputing.
-    // The cross set reverse scan already traversed the same tiles in the
-    // same order, so cross_set_buffer[j].p is the GADDAG state at each
-    // nonempty position.
+    // Look up child tile bitmasks from precomputed letter_bits table.
     let mut group_right_empty: usize = len;
     for j in (0..len).rev() {
         if cross_set_buffer[j].b_letter != 0 {
@@ -1041,10 +1042,13 @@ fn gen_extension_sets<N: kwg::Node>(
             if j + 1 < len && cross_set_buffer[j + 1].b_letter != 0 {
                 // Empty square immediately left of a tile group.
                 let p = cross_set_buffer[j + 1].p;
-                left_extension_sets[j] = collect_bits(kwg, p);
+                left_extension_sets[j] = extension_bits_from_letter_bits(kwg, letter_bits, p);
                 if group_right_empty < len {
-                    right_extension_sets[group_right_empty] =
-                        collect_bits(kwg, if p > 0 { kwg.seek(p, 0) } else { -1 });
+                    right_extension_sets[group_right_empty] = extension_bits_from_letter_bits(
+                        kwg,
+                        letter_bits,
+                        if p > 0 { kwg.seek(p, 0) } else { -1 },
+                    );
                 }
             }
         }
@@ -1052,8 +1056,11 @@ fn gen_extension_sets<N: kwg::Node>(
     // Handle group starting at position 0.
     if len > 0 && cross_set_buffer[0].b_letter != 0 && group_right_empty < len {
         let p = cross_set_buffer[0].p;
-        right_extension_sets[group_right_empty] =
-            collect_bits(kwg, if p > 0 { kwg.seek(p, 0) } else { -1 });
+        right_extension_sets[group_right_empty] = extension_bits_from_letter_bits(
+            kwg,
+            letter_bits,
+            if p > 0 { kwg.seek(p, 0) } else { -1 },
+        );
     }
 }
 
@@ -3137,6 +3144,9 @@ fn kurnia_gen_place_moves_iter<
         board_snapshot.game_config.game_rules(),
         game_config::GameRules::Classic
     ) {
+        let letter_bits = working_buffer
+            .kwg_letter_bits
+            .get_or_insert_with(|| board_snapshot.kwg.compute_letter_bits());
         for row in 0..dim.rows {
             let strip_range_start = (row as isize * dim.cols as isize) as usize;
             let strip_range_end = strip_range_start + dim.cols as usize;
@@ -3151,6 +3161,7 @@ fn kurnia_gen_place_moves_iter<
                     .fill(!0u64);
                 gen_extension_sets(
                     board_snapshot.kwg,
+                    letter_bits,
                     &working_buffer.cross_set_buffer_for_down_plays
                         [strip_range_start..strip_range_end],
                     &mut working_buffer.left_extension_set_for_across_plays
@@ -3178,6 +3189,7 @@ fn kurnia_gen_place_moves_iter<
                     .fill(!0u64);
                 gen_extension_sets(
                     board_snapshot.kwg,
+                    letter_bits,
                     &working_buffer.cross_set_buffer_for_across_plays
                         [strip_range_start..strip_range_end],
                     &mut working_buffer.left_extension_set_for_down_plays

--- a/src/movegen.rs
+++ b/src/movegen.rs
@@ -724,118 +724,55 @@ fn gen_classic_cross_set<'a, N: kwg::Node, L: kwg::Node>(
             j += 1;
             // [j-1] has left and right.
             let j_end = cross_set_buffer[j as usize].end_range;
-            let mut p_right = cross_set_buffer[j as usize].p;
-            let mut p_left = kwg.seek(cross_set_buffer[prev_j as usize].p, 0);
+            let p_right = cross_set_buffer[j as usize].p;
+            let p_left = kwg.seek(cross_set_buffer[prev_j as usize].p, 0);
             let mut bits = reuse_cross_set(cached_cross_sets, j - 1, p_left, p_right);
             if bits == 0 {
                 bits = 1u64;
                 if p_right > 0 && p_left > 0 {
-                    p_right = kwg[p_right].arc_index();
-                    if p_right > 0 {
-                        p_left = kwg[p_left].arc_index();
-                        if p_left > 0 {
-                            let mut node_left = kwg[p_left];
-                            let mut node_right = kwg[p_right];
-                            let mut node_left_tile = node_left.tile();
-                            if j_end - j > j - 1 - prev_j {
-                                // Right is longer than left.
-                                loop {
-                                    match node_left_tile.cmp(&node_right.tile()) {
-                                        std::cmp::Ordering::Less => {
-                                            // left < right: advance left
-                                            if node_left.is_end() {
-                                                break;
-                                            }
-                                            p_left += 1;
-                                            node_left = kwg[p_left];
-                                            node_left_tile = node_left.tile();
-                                        }
-                                        std::cmp::Ordering::Greater => {
-                                            // left > right: advance right
-                                            if node_right.is_end() {
-                                                break;
-                                            }
-                                            p_right += 1;
-                                            node_right = kwg[p_right];
-                                        }
-                                        std::cmp::Ordering::Equal => {
-                                            // left == right (right is longer than left):
-                                            // complete right half with the shorter left half
-                                            let mut q = p_right;
-                                            for qi in (prev_j..j - 1).rev() {
-                                                q = kwg.seek(
-                                                    q,
-                                                    cross_set_buffer[qi as usize].b_letter,
-                                                );
-                                                if q <= 0 {
-                                                    break;
-                                                }
-                                            }
-                                            if q > 0 {
-                                                bits |= (kwg[q].accepts() as u64) << node_left_tile;
-                                            }
-                                            if node_left.is_end() {
-                                                break;
-                                            }
-                                            p_left += 1;
-                                            node_left = kwg[p_left];
-                                            node_left_tile = node_left.tile();
-                                            if node_right.is_end() {
-                                                break;
-                                            }
-                                            p_right += 1;
-                                            node_right = kwg[p_right];
+                    let arc_right = kwg[p_right].arc_index();
+                    let arc_left = kwg[p_left].arc_index();
+                    if arc_right > 0 && arc_left > 0 {
+                        // Pre-filter: only tiles present in both child sets
+                        // need full word verification.
+                        let mut candidates = letter_bits.letter_bits[arc_right as usize]
+                            & letter_bits.letter_bits[arc_left as usize]
+                            & !1; // exclude separator
+                        if j_end - j > j - 1 - prev_j {
+                            // Right is longer than left: verify by traversing
+                            // the right path through the shorter left tiles.
+                            while candidates != 0 {
+                                let tile = candidates.trailing_zeros() as u8;
+                                candidates &= candidates - 1;
+                                let mut q = kwg.seek(p_right, tile);
+                                if q > 0 {
+                                    for qi in (prev_j..j - 1).rev() {
+                                        q = kwg.seek(q, cross_set_buffer[qi as usize].b_letter);
+                                        if q <= 0 {
+                                            break;
                                         }
                                     }
+                                    if q > 0 {
+                                        bits |= (kwg[q].accepts() as u64) << tile;
+                                    }
                                 }
-                            } else {
-                                loop {
-                                    match node_left_tile.cmp(&node_right.tile()) {
-                                        std::cmp::Ordering::Less => {
-                                            // left < right: advance left
-                                            if node_left.is_end() {
-                                                break;
-                                            }
-                                            p_left += 1;
-                                            node_left = kwg[p_left];
-                                            node_left_tile = node_left.tile();
+                            }
+                        } else {
+                            // Left is longer or equal: verify by traversing
+                            // the left path through the right tiles.
+                            while candidates != 0 {
+                                let tile = candidates.trailing_zeros() as u8;
+                                candidates &= candidates - 1;
+                                let mut q = kwg.seek(p_left, tile);
+                                if q > 0 {
+                                    for qi in j..j_end {
+                                        q = kwg.seek(q, cross_set_buffer[qi as usize].b_letter);
+                                        if q <= 0 {
+                                            break;
                                         }
-                                        std::cmp::Ordering::Greater => {
-                                            // left > right: advance right
-                                            if node_right.is_end() {
-                                                break;
-                                            }
-                                            p_right += 1;
-                                            node_right = kwg[p_right];
-                                        }
-                                        std::cmp::Ordering::Equal => {
-                                            // left == right (right is not longer than left):
-                                            // complete left half with right half
-                                            let mut q = p_left;
-                                            for qi in j..j_end {
-                                                q = kwg.seek(
-                                                    q,
-                                                    cross_set_buffer[qi as usize].b_letter,
-                                                );
-                                                if q <= 0 {
-                                                    break;
-                                                }
-                                            }
-                                            if q > 0 {
-                                                bits |= (kwg[q].accepts() as u64) << node_left_tile;
-                                            }
-                                            if node_right.is_end() {
-                                                break;
-                                            }
-                                            p_right += 1;
-                                            node_right = kwg[p_right];
-                                            if node_left.is_end() {
-                                                break;
-                                            }
-                                            p_left += 1;
-                                            node_left = kwg[p_left];
-                                            node_left_tile = node_left.tile();
-                                        }
+                                    }
+                                    if q > 0 {
+                                        bits |= (kwg[q].accepts() as u64) << tile;
                                     }
                                 }
                             }

--- a/src/movegen.rs
+++ b/src/movegen.rs
@@ -621,6 +621,7 @@ fn gen_classic_cross_set<'a, N: kwg::Node, L: kwg::Node>(
     output_strider: matrix::Strider,
     cross_set_buffer: &'a mut [CrossSetComputation],
     cached_cross_sets: &'a mut [CachedCrossSet],
+    letter_bits: &kwg::LetterBits,
 ) {
     let len = output_strider.len();
     let step = output_strider.step() as usize;
@@ -691,21 +692,14 @@ fn gen_classic_cross_set<'a, N: kwg::Node, L: kwg::Node>(
     while j < len {
         if j > 0 {
             // [j-1] has right, no left.
-            let mut p = cross_set_buffer[j as usize].p;
+            let p = cross_set_buffer[j as usize].p;
             let mut bits = reuse_cross_set(cached_cross_sets, j - 1, -2, p);
             if bits == 0 {
                 bits = 1u64;
                 if p > 0 {
-                    p = kwg[p].arc_index();
-                    if p > 0 {
-                        loop {
-                            let node = kwg[p];
-                            bits |= (node.accepts() as u64) << node.tile();
-                            if node.is_end() {
-                                break;
-                            }
-                            p += 1;
-                        }
+                    let arc = kwg[p].arc_index();
+                    if arc > 0 {
+                        bits |= letter_bits.accepting_bits[arc as usize];
                     }
                 }
                 cached_cross_sets[j as usize - 1].bits = bits;
@@ -867,21 +861,14 @@ fn gen_classic_cross_set<'a, N: kwg::Node, L: kwg::Node>(
             break;
         }
         // [j] has left, no right.
-        let mut p = kwg.seek(cross_set_buffer[prev_j as usize].p, 0);
+        let p = kwg.seek(cross_set_buffer[prev_j as usize].p, 0);
         let mut bits = reuse_cross_set(cached_cross_sets, j, p, -2);
         if bits == 0 {
             bits = 1u64;
             if p > 0 {
-                p = kwg[p].arc_index();
-                if p > 0 {
-                    loop {
-                        let node = kwg[p];
-                        bits |= (node.accepts() as u64) << node.tile();
-                        if node.is_end() {
-                            break;
-                        }
-                        p += 1;
-                    }
+                let arc = kwg[p].arc_index();
+                if arc > 0 {
+                    bits |= letter_bits.accepting_bits[arc as usize];
                 }
             }
             cached_cross_sets[j as usize].bits = bits;
@@ -976,6 +963,7 @@ fn gen_cross_set<'a, N: kwg::Node, L: kwg::Node>(
     cross_set_buffer: &'a mut [CrossSetComputation],
     cached_cross_sets: &'a mut [CachedCrossSet],
     used_letters_tally: &'a mut [u8],
+    letter_bits: &kwg::LetterBits,
 ) {
     match board_snapshot.game_config.game_rules() {
         game_config::GameRules::Classic => gen_classic_cross_set(
@@ -985,6 +973,7 @@ fn gen_cross_set<'a, N: kwg::Node, L: kwg::Node>(
             output_strider,
             cross_set_buffer,
             cached_cross_sets,
+            letter_bits,
         ),
         game_config::GameRules::Jumbled => gen_jumbled_cross_set(
             board_snapshot,
@@ -3073,6 +3062,11 @@ fn kurnia_gen_place_moves_iter<
     let max_rack_size = game_config.rack_size();
     let num_max_played = max_rack_size.min(working_buffer.num_tiles_on_rack);
 
+    // Lazily compute letter_bits table for the current KWG.
+    let letter_bits = working_buffer
+        .kwg_letter_bits
+        .get_or_insert_with(|| board_snapshot.kwg.compute_letter_bits());
+
     // striped by row
     let mut any_across_strip_changed = false;
     for col in 0..dim.cols {
@@ -3091,6 +3085,7 @@ fn kurnia_gen_place_moves_iter<
                 &mut working_buffer.cached_cross_set_for_across_plays
                     [strip_range_start..strip_range_end],
                 &mut working_buffer.used_letters_tally,
+                letter_bits,
             );
             working_buffer.prev_board_for_across_cross_sets[strip_range_start..strip_range_end]
                 .copy_from_slice(
@@ -3121,6 +3116,7 @@ fn kurnia_gen_place_moves_iter<
                 &mut working_buffer.cached_cross_set_for_down_plays
                     [strip_range_start..strip_range_end],
                 &mut working_buffer.used_letters_tally,
+                letter_bits,
             );
             working_buffer.prev_board_for_down_cross_sets[strip_range_start..strip_range_end]
                 .copy_from_slice(&board_snapshot.board_tiles[strip_range_start..strip_range_end]);
@@ -3144,9 +3140,8 @@ fn kurnia_gen_place_moves_iter<
         board_snapshot.game_config.game_rules(),
         game_config::GameRules::Classic
     ) {
-        let letter_bits = working_buffer
-            .kwg_letter_bits
-            .get_or_insert_with(|| board_snapshot.kwg.compute_letter_bits());
+        // letter_bits already initialized above, before cross set loops.
+        let letter_bits = working_buffer.kwg_letter_bits.as_ref().unwrap();
         for row in 0..dim.rows {
             let strip_range_start = (row as isize * dim.cols as isize) as usize;
             let strip_range_end = strip_range_start + dim.cols as usize;

--- a/src/movegen.rs
+++ b/src/movegen.rs
@@ -1017,7 +1017,7 @@ fn extension_bits_from_letter_bits<N: kwg::Node>(
     if arc <= 0 {
         return 0;
     }
-    let bits = letter_bits.0[arc as usize] & !1;
+    let bits = letter_bits.letter_bits[arc as usize] & !1;
     bits | (bits != 0) as u64
 }
 

--- a/src/movegen.rs
+++ b/src/movegen.rs
@@ -95,7 +95,6 @@ struct WorkingBuffer {
     used_tile_scores_shadowr: Vec<i8>, // rack.len() (for shadow_play_right)
     rack_tally_shadowl: Box<[u8]>, // 27 for ?A-Z (for shadow_play_left)
     rack_tally_shadowr: Box<[u8]>, // 27 for ?A-Z (for shadow_play_right)
-    kwg_letter_bits: Option<kwg::LetterBits>, // precomputed child tile bitmasks, lazily initialized
 }
 
 impl Clone for WorkingBuffer {
@@ -161,12 +160,11 @@ impl Clone for WorkingBuffer {
             best_leave_values: self.best_leave_values.clone(),
             found_placements: self.found_placements.clone(),
             used_letters_tally: self.used_letters_tally.clone(),
-            accepts_alpha_cache: self.accepts_alpha_cache.clone(), // jumbled mode only
+            accepts_alpha_cache: self.accepts_alpha_cache.clone(),
             used_tile_scores_shadowl: self.used_tile_scores_shadowl.clone(),
             used_tile_scores_shadowr: self.used_tile_scores_shadowr.clone(),
             rack_tally_shadowl: self.rack_tally_shadowl.clone(),
             rack_tally_shadowr: self.rack_tally_shadowr.clone(),
-            kwg_letter_bits: self.kwg_letter_bits.clone(),
         }
     }
 
@@ -258,7 +256,6 @@ impl Clone for WorkingBuffer {
             .clone_from(&source.rack_tally_shadowl);
         self.rack_tally_shadowr
             .clone_from(&source.rack_tally_shadowr);
-        self.kwg_letter_bits.clone_from(&source.kwg_letter_bits);
     }
 }
 
@@ -366,7 +363,6 @@ impl WorkingBuffer {
             used_tile_scores_shadowr: Vec::new(),
             rack_tally_shadowl: vec![0u8; game_config.alphabet().len() as usize].into_boxed_slice(),
             rack_tally_shadowr: vec![0u8; game_config.alphabet().len() as usize].into_boxed_slice(),
-            kwg_letter_bits: None,
         }
     }
 
@@ -600,7 +596,6 @@ impl WorkingBuffer {
         self.right_extension_set_for_across_plays.fill(!0u64);
         self.left_extension_set_for_down_plays.fill(!0u64);
         self.right_extension_set_for_down_plays.fill(!0u64);
-        self.kwg_letter_bits = None;
         self.accepts_alpha_cache.fill(([0u8; 64], false));
     }
 }
@@ -621,8 +616,25 @@ fn gen_classic_cross_set<'a, N: kwg::Node, L: kwg::Node>(
     output_strider: matrix::Strider,
     cross_set_buffer: &'a mut [CrossSetComputation],
     cached_cross_sets: &'a mut [CachedCrossSet],
-    letter_bits: &kwg::LetterBits,
 ) {
+    // Compute bitmask of tiles in a sibling group on the fly.
+    let sibling_bits = |kwg: &kwg::Kwg<N>, mut p: i32, accepting_only: bool| -> u64 {
+        let mut bits = 0u64;
+        if p > 0 {
+            loop {
+                let node = kwg[p];
+                if !accepting_only || node.accepts() {
+                    bits |= 1u64 << node.tile();
+                }
+                if node.is_end() {
+                    break;
+                }
+                p += 1;
+            }
+        }
+        bits
+    };
+
     let len = output_strider.len();
     let step = output_strider.step() as usize;
     let kwg = board_snapshot.kwg;
@@ -698,9 +710,7 @@ fn gen_classic_cross_set<'a, N: kwg::Node, L: kwg::Node>(
                 bits = 1u64;
                 if p > 0 {
                     let arc = kwg[p].arc_index();
-                    if arc > 0 {
-                        bits |= letter_bits.accepting_bits[arc as usize];
-                    }
+                    bits |= sibling_bits(kwg, arc, true);
                 }
                 cached_cross_sets[j as usize - 1].bits = bits;
             }
@@ -735,8 +745,8 @@ fn gen_classic_cross_set<'a, N: kwg::Node, L: kwg::Node>(
                     if arc_right > 0 && arc_left > 0 {
                         // Pre-filter: only tiles present in both child sets
                         // need full word verification.
-                        let mut candidates = letter_bits.letter_bits[arc_right as usize]
-                            & letter_bits.letter_bits[arc_left as usize]
+                        let mut candidates = sibling_bits(kwg, arc_right, false)
+                            & sibling_bits(kwg, arc_left, false)
                             & !1; // exclude separator
                         if j_end - j > j - 1 - prev_j {
                             // Right is longer than left: verify by traversing
@@ -804,9 +814,7 @@ fn gen_classic_cross_set<'a, N: kwg::Node, L: kwg::Node>(
             bits = 1u64;
             if p > 0 {
                 let arc = kwg[p].arc_index();
-                if arc > 0 {
-                    bits |= letter_bits.accepting_bits[arc as usize];
-                }
+                bits |= sibling_bits(kwg, arc, true);
             }
             cached_cross_sets[j as usize].bits = bits;
         }
@@ -900,7 +908,6 @@ fn gen_cross_set<'a, N: kwg::Node, L: kwg::Node>(
     cross_set_buffer: &'a mut [CrossSetComputation],
     cached_cross_sets: &'a mut [CachedCrossSet],
     used_letters_tally: &'a mut [u8],
-    letter_bits: &kwg::LetterBits,
 ) {
     match board_snapshot.game_config.game_rules() {
         game_config::GameRules::Classic => gen_classic_cross_set(
@@ -910,7 +917,6 @@ fn gen_cross_set<'a, N: kwg::Node, L: kwg::Node>(
             output_strider,
             cross_set_buffer,
             cached_cross_sets,
-            letter_bits,
         ),
         game_config::GameRules::Jumbled => gen_jumbled_cross_set(
             board_snapshot,
@@ -928,28 +934,32 @@ fn gen_cross_set<'a, N: kwg::Node, L: kwg::Node>(
 // Right extension set at position j: which tiles can extend rightward into j,
 // given the board tiles to the left of j.
 // Non-adjacent empty squares get !0u64 (all bits, no constraint).
-// Look up child tile bitmask from precomputed letter_bits table.
+// Collect extension set bits from a GADDAG node's children.
 // Excludes separator (bit 0), then adds blank bit if non-empty.
 #[inline(always)]
-fn extension_bits_from_letter_bits<N: kwg::Node>(
-    kwg: &kwg::Kwg<N>,
-    letter_bits: &kwg::LetterBits,
-    p: i32,
-) -> u64 {
+fn collect_extension_bits<N: kwg::Node>(kwg: &kwg::Kwg<N>, p: i32) -> u64 {
     if p <= 0 {
         return 0;
     }
-    let arc = kwg[p].arc_index();
+    let mut arc = kwg[p].arc_index();
     if arc <= 0 {
         return 0;
     }
-    let bits = letter_bits.letter_bits[arc as usize] & !1;
+    let mut bits = 0u64;
+    loop {
+        let node = kwg[arc];
+        bits |= 1u64 << node.tile();
+        if node.is_end() {
+            break;
+        }
+        arc += 1;
+    }
+    let bits = bits & !1;
     bits | (bits != 0) as u64
 }
 
 fn gen_extension_sets<N: kwg::Node>(
     kwg: &kwg::Kwg<N>,
-    letter_bits: &kwg::LetterBits,
     cross_set_buffer: &[CrossSetComputation],
     left_extension_sets: &mut [u64],
     right_extension_sets: &mut [u64],
@@ -957,7 +967,6 @@ fn gen_extension_sets<N: kwg::Node>(
     let len = cross_set_buffer.len();
 
     // Read GADDAG state (p) from cross_set_buffer instead of recomputing.
-    // Look up child tile bitmasks from precomputed letter_bits table.
     let mut group_right_empty: usize = len;
     for j in (0..len).rev() {
         if cross_set_buffer[j].b_letter != 0 {
@@ -968,13 +977,10 @@ fn gen_extension_sets<N: kwg::Node>(
             if j + 1 < len && cross_set_buffer[j + 1].b_letter != 0 {
                 // Empty square immediately left of a tile group.
                 let p = cross_set_buffer[j + 1].p;
-                left_extension_sets[j] = extension_bits_from_letter_bits(kwg, letter_bits, p);
+                left_extension_sets[j] = collect_extension_bits(kwg, p);
                 if group_right_empty < len {
-                    right_extension_sets[group_right_empty] = extension_bits_from_letter_bits(
-                        kwg,
-                        letter_bits,
-                        if p > 0 { kwg.seek(p, 0) } else { -1 },
-                    );
+                    right_extension_sets[group_right_empty] =
+                        collect_extension_bits(kwg, if p > 0 { kwg.seek(p, 0) } else { -1 });
                 }
             }
         }
@@ -982,11 +988,8 @@ fn gen_extension_sets<N: kwg::Node>(
     // Handle group starting at position 0.
     if len > 0 && cross_set_buffer[0].b_letter != 0 && group_right_empty < len {
         let p = cross_set_buffer[0].p;
-        right_extension_sets[group_right_empty] = extension_bits_from_letter_bits(
-            kwg,
-            letter_bits,
-            if p > 0 { kwg.seek(p, 0) } else { -1 },
-        );
+        right_extension_sets[group_right_empty] =
+            collect_extension_bits(kwg, if p > 0 { kwg.seek(p, 0) } else { -1 });
     }
 }
 
@@ -3000,11 +3003,6 @@ fn kurnia_gen_place_moves_iter<
     let max_rack_size = game_config.rack_size();
     let num_max_played = max_rack_size.min(working_buffer.num_tiles_on_rack);
 
-    // Lazily compute letter_bits table for the current KWG.
-    let letter_bits = working_buffer
-        .kwg_letter_bits
-        .get_or_insert_with(|| board_snapshot.kwg.compute_letter_bits());
-
     // striped by row
     let mut any_across_strip_changed = false;
     for col in 0..dim.cols {
@@ -3023,7 +3021,6 @@ fn kurnia_gen_place_moves_iter<
                 &mut working_buffer.cached_cross_set_for_across_plays
                     [strip_range_start..strip_range_end],
                 &mut working_buffer.used_letters_tally,
-                letter_bits,
             );
             working_buffer.prev_board_for_across_cross_sets[strip_range_start..strip_range_end]
                 .copy_from_slice(
@@ -3054,7 +3051,6 @@ fn kurnia_gen_place_moves_iter<
                 &mut working_buffer.cached_cross_set_for_down_plays
                     [strip_range_start..strip_range_end],
                 &mut working_buffer.used_letters_tally,
-                letter_bits,
             );
             working_buffer.prev_board_for_down_cross_sets[strip_range_start..strip_range_end]
                 .copy_from_slice(&board_snapshot.board_tiles[strip_range_start..strip_range_end]);
@@ -3078,8 +3074,6 @@ fn kurnia_gen_place_moves_iter<
         board_snapshot.game_config.game_rules(),
         game_config::GameRules::Classic
     ) {
-        // letter_bits already initialized above, before cross set loops.
-        let letter_bits = working_buffer.kwg_letter_bits.as_ref().unwrap();
         for row in 0..dim.rows {
             let strip_range_start = (row as isize * dim.cols as isize) as usize;
             let strip_range_end = strip_range_start + dim.cols as usize;
@@ -3094,7 +3088,6 @@ fn kurnia_gen_place_moves_iter<
                     .fill(!0u64);
                 gen_extension_sets(
                     board_snapshot.kwg,
-                    letter_bits,
                     &working_buffer.cross_set_buffer_for_down_plays
                         [strip_range_start..strip_range_end],
                     &mut working_buffer.left_extension_set_for_across_plays
@@ -3122,7 +3115,6 @@ fn kurnia_gen_place_moves_iter<
                     .fill(!0u64);
                 gen_extension_sets(
                     board_snapshot.kwg,
-                    letter_bits,
                     &working_buffer.cross_set_buffer_for_across_plays
                         [strip_range_start..strip_range_end],
                     &mut working_buffer.left_extension_set_for_down_plays


### PR DESCRIPTION
## Summary

- Precompute LetterBits table (letter_bits + accepting_bits per KWG sibling group) for O(1) child tile lookups
- Replace iterative child loops in one-sided cross set cases with accepting_bits lookup
- Replace sorted merge-intersect in left-and-right cross set case with letter_bits AND pre-filter
- Skip dead anchors (both extension sets zero) regardless of want_raw mode
- Drop 24MB LetterBits table from WorkingBuffer — compute bitmasks on the fly instead (cache-friendly, WASM-safe)
- Keep LetterBits struct in kwg.rs for callers that want precomputed tables

## Test plan

- [x] movegen baseline unchanged across all commits
- [x] cargo fmt, clippy, build pass on all commits