### PR TITLE
fix leave_idx overflow in shadow play for large racks

### DIFF
--- a/src/movegen.rs
+++ b/src/movegen.rs
@@ -1659,7 +1659,9 @@ fn gen_classic_place_moves<
                         + perpendicular_score
                         + tile_value * perpendicular_word_multiplier as i32,
                     word_multiplier: new_word_multiplier,
-                    leave_idx: acc.leave_idx - env.params.multi_leaves.place_value(0),
+                    leave_idx: acc
+                        .leave_idx
+                        .wrapping_sub(env.params.multi_leaves.place_value(0)),
                 }
             });
             loop {
@@ -1678,8 +1680,9 @@ fn gen_classic_place_moves<
                                     + perpendicular_score
                                     + tile_value * perpendicular_word_multiplier as i32,
                                 word_multiplier: new_word_multiplier,
-                                leave_idx: acc.leave_idx
-                                    - env.params.multi_leaves.place_value(tile),
+                                leave_idx: acc
+                                    .leave_idx
+                                    .wrapping_sub(env.params.multi_leaves.place_value(tile)),
                             },
                             p,
                             idx + 1,
@@ -1804,7 +1807,9 @@ fn gen_classic_place_moves<
                         + perpendicular_score
                         + tile_value * perpendicular_word_multiplier as i32,
                     word_multiplier: new_word_multiplier,
-                    leave_idx: acc.leave_idx - env.params.multi_leaves.place_value(0),
+                    leave_idx: acc
+                        .leave_idx
+                        .wrapping_sub(env.params.multi_leaves.place_value(0)),
                 }
             });
             loop {
@@ -1823,8 +1828,9 @@ fn gen_classic_place_moves<
                                     + perpendicular_score
                                     + tile_value * perpendicular_word_multiplier as i32,
                                 word_multiplier: new_word_multiplier,
-                                leave_idx: acc.leave_idx
-                                    - env.params.multi_leaves.place_value(tile),
+                                leave_idx: acc
+                                    .leave_idx
+                                    .wrapping_sub(env.params.multi_leaves.place_value(tile)),
                             },
                             p,
                             idx - 1,
@@ -2020,7 +2026,9 @@ fn gen_jumbled_place_moves<
                             + perpendicular_score
                             + tile_value * perpendicular_word_multiplier as i32,
                         word_multiplier: new_word_multiplier,
-                        leave_idx: acc.leave_idx - env.params.multi_leaves.place_value(0),
+                        leave_idx: acc
+                            .leave_idx
+                            .wrapping_sub(env.params.multi_leaves.place_value(0)),
                     }
                 });
                 for tile in 1..env.alphabet.len() {
@@ -2122,7 +2130,9 @@ fn gen_jumbled_place_moves<
                                 + perpendicular_score
                                 + tile_value * perpendicular_word_multiplier as i32,
                             word_multiplier: new_word_multiplier,
-                            leave_idx: acc.leave_idx - env.params.multi_leaves.place_value(0),
+                            leave_idx: acc
+                                .leave_idx
+                                .wrapping_sub(env.params.multi_leaves.place_value(0)),
                         }
                     });
                     for tile in 1..env.alphabet.len() {


### PR DESCRIPTION
## Summary
- Shadow play's `leave_idx` subtraction panicked in debug mode for non-dense MultiLeaves (e.g. 90-tile threat analysis rack)
- When MultiLeaves is not dense, `leave_idx` is meaningless (`leave_value()` returns 0), but `acc.leave_idx - place_value(tile)` could underflow for u32
- Use `wrapping_sub` which compiles to the same `sub` instruction in release builds (no perf impact) and avoids the debug panic
- Bug existed since 6e57cb2 (2026-03-22) which added both the overflow handling and the test case that triggered it
- All 17 movegen-test cases now pass (273 moves), including case 16 (90-tile rack, 170ms)

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets`
- [x] `cargo build`
- [x] `cargo test`
- [x] `cargo run --bin movegen-test` (all 17 cases pass, was panicking on case 16)