### PR TITLE
fix movegen regression for plays spanning multiple tile groups

### DIFF
--- a/src/main_movegen_test.rs
+++ b/src/main_movegen_test.rs
@@ -139,6 +139,14 @@ static TEST_CASES: &[TestCase] = &[
         always_include_pass: false,
         num_exchanges_by_this_player: 0,
     },
+    // Multi-group through-play: TENSIONAL spans two separate board tile groups
+    TestCase {
+        fen: "13V1/13I1/10YEGGS/7PHLOX2U/6GROAN3A/J3OWIE6B/ENNUI2B2A3L/T6UT1N1M1E/E6YO1O1A2/8R1DUI2/7SI1i1D1L/7HI1Z1h1E/1PLECTRA2E1O1A/7WARRIORS/7N4D1E",
+        rack: "AEINOST",
+        max_gen: 15,
+        always_include_pass: false,
+        num_exchanges_by_this_player: i16::MAX, // skip exchanges (bag likely too small)
+    },
     // Large rack (threat analysis: all unseen tiles), MultiLeaves overflow
     TestCase {
         fen: "15/15/15/15/15/15/15/4WORD7/15/15/15/15/15/15/15",

--- a/src/movegen.rs
+++ b/src/movegen.rs
@@ -1501,8 +1501,6 @@ struct GenPlaceMovesParams<'a, CallbackType: FnMut(i8, &[u8], i32, i32), N: kwg:
     board_strip: &'a [u8],
     cross_set_strip: &'a [CrossSet],
     cross_set_buffer_strip: &'a [CrossSetComputation], // cached GADDAG state per position
-    left_extension_strip: &'a [u64],
-    right_extension_strip: &'a [u64],
     remaining_word_multipliers_strip: &'a [i8],
     remaining_tile_multipliers_strip: &'a [i8],
     face_value_scores_strip: &'a [i32],
@@ -1636,11 +1634,6 @@ fn gen_classic_place_moves<
                 this_cross_bits = !1;
                 is_unique = true;
             };
-            // Filter by left extension set (tiles to the right the traversal hasn't seen).
-            this_cross_bits &= env.params.left_extension_strip[idx as usize];
-            if this_cross_bits == 0 {
-                return;
-            }
             let new_word_multiplier = acc.word_multiplier
                 * env.params.remaining_word_multipliers_strip[idx as usize] as i32;
             let tile_multiplier = env.params.remaining_tile_multipliers_strip[idx as usize];
@@ -1785,11 +1778,6 @@ fn gen_classic_place_moves<
             } else {
                 this_cross_bits = !1;
                 is_unique = true;
-            }
-            // Filter by right extension set (tiles to the left the traversal hasn't seen).
-            this_cross_bits &= env.params.right_extension_strip[idx as usize];
-            if this_cross_bits == 0 {
-                return;
             }
             let new_word_multiplier = acc.word_multiplier
                 * env.params.remaining_word_multipliers_strip[idx as usize] as i32;
@@ -2267,20 +2255,6 @@ fn gen_place_moves_at<
                     [strip_range_start..strip_range_end]
             } else {
                 &working_buffer.cross_set_buffer_for_down_plays[strip_range_start..strip_range_end]
-            },
-            left_extension_strip: if placement.down {
-                &working_buffer.left_extension_set_for_down_plays
-                    [strip_range_start..strip_range_end]
-            } else {
-                &working_buffer.left_extension_set_for_across_plays
-                    [strip_range_start..strip_range_end]
-            },
-            right_extension_strip: if placement.down {
-                &working_buffer.right_extension_set_for_down_plays
-                    [strip_range_start..strip_range_end]
-            } else {
-                &working_buffer.right_extension_set_for_across_plays
-                    [strip_range_start..strip_range_end]
             },
             remaining_word_multipliers_strip: if placement.down {
                 &working_buffer.remaining_word_multipliers_for_down_plays


### PR DESCRIPTION
## Summary
- Add test case for TENSIONAL position (https://woogles.io/game/Hra8KdvPea?turn=20) where a play spans two separate board tile groups (N at row 7 and L at row 13 in column C)
- Remove extension set filtering from `gen_classic_place_moves` (play_left and play_right) which incorrectly pruned these multi-group plays

## Root cause
Extension sets at positions adjacent to intermediate board tile groups are computed from that group's independent GADDAG state. During word generation, the actual GADDAG state comes from the *anchor's* path, which diverges when traversing through intermediate groups. This causes valid tiles to be rejected — e.g. S at position 8 in column C is valid in L's GADDAG path (L→A→N→O→I→S) but absent from N's root extension set.

Introduced in 011f76d (use extension sets in word generation), PR #15. The shadow play retains its extension set filtering since it processes each group independently with consistent GADDAG states.

## Test plan
- [x] `movegen-test` case 16 now includes TENSIONAL (`C5 TE(N)SIONA(L) 60`) in top 15
- [x] All other test cases unchanged
- [x] `cargo clippy --all-targets` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)