### PR TITLE
remove extension set filtering from shadow placement pass

### DIFF
--- a/src/movegen.rs
+++ b/src/movegen.rs
@@ -69,10 +69,6 @@ struct WorkingBuffer {
     perpendicular_word_multipliers_for_down_plays: Box<[i8]>,   // c*r
     perpendicular_scores_for_across_plays: Box<[i32]>, // r*c (multiplied by perpendicular_word_multipliers)
     perpendicular_scores_for_down_plays: Box<[i32]>,   // c*r
-    left_extension_set_for_across_plays: Box<[u64]>,   // r*c
-    right_extension_set_for_across_plays: Box<[u64]>,  // r*c
-    left_extension_set_for_down_plays: Box<[u64]>,     // c*r
-    right_extension_set_for_down_plays: Box<[u64]>,    // c*r
     transposed_board_tiles: Box<[u8]>,                 // c*r
     num_tiles_on_board: u16,
     num_tiles_in_bag: i16, // negative when players also have less than full racks
@@ -134,10 +130,6 @@ impl Clone for WorkingBuffer {
                 .perpendicular_scores_for_across_plays
                 .clone(),
             perpendicular_scores_for_down_plays: self.perpendicular_scores_for_down_plays.clone(),
-            left_extension_set_for_across_plays: self.left_extension_set_for_across_plays.clone(),
-            right_extension_set_for_across_plays: self.right_extension_set_for_across_plays.clone(),
-            left_extension_set_for_down_plays: self.left_extension_set_for_down_plays.clone(),
-            right_extension_set_for_down_plays: self.right_extension_set_for_down_plays.clone(),
             transposed_board_tiles: self.transposed_board_tiles.clone(),
             num_tiles_on_board: self.num_tiles_on_board,
             num_tiles_in_bag: self.num_tiles_in_bag,
@@ -204,14 +196,6 @@ impl Clone for WorkingBuffer {
             .clone_from(&source.perpendicular_scores_for_across_plays);
         self.perpendicular_scores_for_down_plays
             .clone_from(&source.perpendicular_scores_for_down_plays);
-        self.left_extension_set_for_across_plays
-            .clone_from(&source.left_extension_set_for_across_plays);
-        self.right_extension_set_for_across_plays
-            .clone_from(&source.right_extension_set_for_across_plays);
-        self.left_extension_set_for_down_plays
-            .clone_from(&source.left_extension_set_for_down_plays);
-        self.right_extension_set_for_down_plays
-            .clone_from(&source.right_extension_set_for_down_plays);
         self.transposed_board_tiles
             .clone_from(&source.transposed_board_tiles);
         self.num_tiles_on_board
@@ -315,10 +299,6 @@ impl WorkingBuffer {
                 .into_boxed_slice(),
             perpendicular_scores_for_across_plays: vec![0i32; rows_times_cols].into_boxed_slice(),
             perpendicular_scores_for_down_plays: vec![0i32; rows_times_cols].into_boxed_slice(),
-            left_extension_set_for_across_plays: vec![!0u64; rows_times_cols].into_boxed_slice(),
-            right_extension_set_for_across_plays: vec![!0u64; rows_times_cols].into_boxed_slice(),
-            left_extension_set_for_down_plays: vec![!0u64; rows_times_cols].into_boxed_slice(),
-            right_extension_set_for_down_plays: vec![!0u64; rows_times_cols].into_boxed_slice(),
             transposed_board_tiles: vec![0u8; rows_times_cols].into_boxed_slice(),
             num_tiles_on_board: 0,
             num_tiles_in_bag: 0,
@@ -580,10 +560,6 @@ impl WorkingBuffer {
             bits: 0,
         });
         self.prev_board_tiles.fill(0xff);
-        self.left_extension_set_for_across_plays.fill(!0u64);
-        self.right_extension_set_for_across_plays.fill(!0u64);
-        self.left_extension_set_for_down_plays.fill(!0u64);
-        self.right_extension_set_for_down_plays.fill(!0u64);
         if let Some(cache) = &mut self.accepts_alpha_cache {
             cache.fill(([0u8; 64], false));
         }
@@ -915,71 +891,6 @@ fn gen_cross_set<'a, N: kwg::Node, L: kwg::Node>(
             output_strider,
             used_letters_tally,
         ),
-    }
-}
-
-// Compute left and right extension sets for a strip in the play direction.
-// Left extension set at position j: which tiles can extend leftward into j,
-// given the board tiles to the right of j.
-// Right extension set at position j: which tiles can extend rightward into j,
-// given the board tiles to the left of j.
-// Non-adjacent empty squares get !0u64 (all bits, no constraint).
-// Collect extension set bits from a GADDAG node's children.
-// Excludes separator (bit 0), then adds blank bit if non-empty.
-#[inline(always)]
-fn collect_extension_bits<N: kwg::Node>(kwg: &kwg::Kwg<N>, p: i32) -> u64 {
-    if p <= 0 {
-        return 0;
-    }
-    let mut arc = kwg[p].arc_index();
-    if arc <= 0 {
-        return 0;
-    }
-    let mut bits = 0u64;
-    loop {
-        let node = kwg[arc];
-        bits |= 1u64 << node.tile();
-        if node.is_end() {
-            break;
-        }
-        arc += 1;
-    }
-    let bits = bits & !1;
-    bits | (bits != 0) as u64
-}
-
-fn gen_extension_sets<N: kwg::Node>(
-    kwg: &kwg::Kwg<N>,
-    cross_set_buffer: &[CrossSetComputation],
-    left_extension_sets: &mut [u64],
-    right_extension_sets: &mut [u64],
-) {
-    let len = cross_set_buffer.len();
-
-    // Read GADDAG state (p) from cross_set_buffer instead of recomputing.
-    let mut group_right_empty: usize = len;
-    for j in (0..len).rev() {
-        if cross_set_buffer[j].b_letter != 0 {
-            if j + 1 == len || cross_set_buffer[j + 1].b_letter == 0 {
-                group_right_empty = j + 1;
-            }
-        } else {
-            if j + 1 < len && cross_set_buffer[j + 1].b_letter != 0 {
-                // Empty square immediately left of a tile group.
-                let p = cross_set_buffer[j + 1].p;
-                left_extension_sets[j] = collect_extension_bits(kwg, p);
-                if group_right_empty < len {
-                    right_extension_sets[group_right_empty] =
-                        collect_extension_bits(kwg, if p > 0 { kwg.seek(p, 0) } else { -1 });
-                }
-            }
-        }
-    }
-    // Handle group starting at position 0.
-    if len > 0 && cross_set_buffer[0].b_letter != 0 && group_right_empty < len {
-        let p = cross_set_buffer[0].p;
-        right_extension_sets[group_right_empty] =
-            collect_extension_bits(kwg, if p > 0 { kwg.seek(p, 0) } else { -1 });
     }
 }
 
@@ -3067,57 +2978,6 @@ fn kurnia_gen_place_moves_iter<
         }
         working_buffer.cross_set_for_across_plays[dim.at_row_col(star_row, star_col)] =
             CrossSet { bits: !1, score: 0 };
-    }
-    // extension sets: per strip in the play direction
-    // Across extension sets use board_tiles (rows), down use transposed_board_tiles (columns).
-    if matches!(
-        board_snapshot.game_config.game_rules(),
-        game_config::GameRules::Classic
-    ) {
-        // Across extension sets: recompute dirty rows.
-        for row in 0..dim.rows {
-            if dirty_rows & (1 << row) != 0 {
-                let strip_range_start = (row as isize * dim.cols as isize) as usize;
-                let strip_range_end = strip_range_start + dim.cols as usize;
-                working_buffer.left_extension_set_for_across_plays
-                    [strip_range_start..strip_range_end]
-                    .fill(!0u64);
-                working_buffer.right_extension_set_for_across_plays
-                    [strip_range_start..strip_range_end]
-                    .fill(!0u64);
-                gen_extension_sets(
-                    board_snapshot.kwg,
-                    &working_buffer.cross_set_buffer_for_down_plays
-                        [strip_range_start..strip_range_end],
-                    &mut working_buffer.left_extension_set_for_across_plays
-                        [strip_range_start..strip_range_end],
-                    &mut working_buffer.right_extension_set_for_across_plays
-                        [strip_range_start..strip_range_end],
-                );
-            }
-        }
-        // Down extension sets: recompute dirty columns.
-        for col in 0..dim.cols {
-            if dirty_cols & (1 << col) != 0 {
-                let strip_range_start = (col as isize * dim.rows as isize) as usize;
-                let strip_range_end = strip_range_start + dim.rows as usize;
-                working_buffer.left_extension_set_for_down_plays
-                    [strip_range_start..strip_range_end]
-                    .fill(!0u64);
-                working_buffer.right_extension_set_for_down_plays
-                    [strip_range_start..strip_range_end]
-                    .fill(!0u64);
-                gen_extension_sets(
-                    board_snapshot.kwg,
-                    &working_buffer.cross_set_buffer_for_across_plays
-                        [strip_range_start..strip_range_end],
-                    &mut working_buffer.left_extension_set_for_down_plays
-                        [strip_range_start..strip_range_end],
-                    &mut working_buffer.right_extension_set_for_down_plays
-                        [strip_range_start..strip_range_end],
-                );
-            }
-        }
     }
     // Update prev_board after all dirty processing is done.
     if dirty_rows != 0 || dirty_cols != 0 {

--- a/src/movegen.rs
+++ b/src/movegen.rs
@@ -991,8 +991,6 @@ struct GenPlacePlacementsParams<'a> {
     used_tile_scores_shadowr: &'a mut Vec<i32>,
     shadow_strip_buffer: &'a mut [u8], // not really storing letters here
     cross_set_strip: &'a [CrossSet],
-    left_extension_strip: &'a [u64],
-    right_extension_strip: &'a [u64],
     remaining_word_multipliers_strip: &'a [i8],
     remaining_tile_multipliers_strip: &'a [i8],
     perpendicular_word_multipliers_strip: &'a [i8],
@@ -1242,8 +1240,7 @@ fn gen_place_placements<'a, PossibleStripPlacementCallbackType: FnMut(i8, i8, i8
             } else if this_cross_bits != 1 {
                 // something hooks here and there is a valid letter.
                 // this_cross_bits has bit 1 set, so blank is always allowed.
-                let matching_bits =
-                    this_cross_bits & rack_bits & env.params.left_extension_strip[idx as usize];
+                let matching_bits = this_cross_bits & rack_bits;
                 if matching_bits == 0 {
                     break;
                 }
@@ -1348,8 +1345,7 @@ fn gen_place_placements<'a, PossibleStripPlacementCallbackType: FnMut(i8, i8, i8
             } else if this_cross_bits != 1 {
                 // something hooks here and there is a valid letter.
                 // this_cross_bits has bit 1 set, so blank is always allowed.
-                let matching_bits =
-                    this_cross_bits & rack_bits & env.params.right_extension_strip[idx as usize];
+                let matching_bits = this_cross_bits & rack_bits;
                 if matching_bits == 0 {
                     break;
                 }
@@ -1410,11 +1406,7 @@ fn gen_place_placements<'a, PossibleStripPlacementCallbackType: FnMut(i8, i8, i8
         want_raw: bool,
         mut possible_strip_placement_callback: PossibleStripPlacementCallbackType,
     ) {
-        if env.params.left_extension_strip[env.anchor as usize] == 0
-            && env.params.right_extension_strip[env.anchor as usize] == 0
-        {
-            // Dead anchor: no tile can extend in either direction.
-        } else if want_raw {
+        if want_raw {
             possible_strip_placement_callback(env.anchor, env.leftmost, env.rightmost, i32::MAX);
         } else {
             env.best_possible_equity = i32::MIN;
@@ -3153,10 +3145,6 @@ fn kurnia_gen_place_moves_iter<
                     [strip_range_start..strip_range_end], // repurpose
                 cross_set_strip: &working_buffer.cross_set_for_across_plays
                     [strip_range_start..strip_range_end],
-                left_extension_strip: &working_buffer.left_extension_set_for_across_plays
-                    [strip_range_start..strip_range_end],
-                right_extension_strip: &working_buffer.right_extension_set_for_across_plays
-                    [strip_range_start..strip_range_end],
                 remaining_word_multipliers_strip: &working_buffer
                     .remaining_word_multipliers_for_across_plays
                     [strip_range_start..strip_range_end],
@@ -3209,10 +3197,6 @@ fn kurnia_gen_place_moves_iter<
                 shadow_strip_buffer: &mut working_buffer.word_buffer_for_down_plays
                     [strip_range_start..strip_range_end], // repurpose
                 cross_set_strip: &working_buffer.cross_set_for_down_plays
-                    [strip_range_start..strip_range_end],
-                left_extension_strip: &working_buffer.left_extension_set_for_down_plays
-                    [strip_range_start..strip_range_end],
-                right_extension_strip: &working_buffer.right_extension_set_for_down_plays
                     [strip_range_start..strip_range_end],
                 remaining_word_multipliers_strip: &working_buffer
                     .remaining_word_multipliers_for_down_plays[strip_range_start..strip_range_end],


### PR DESCRIPTION
## Summary
- Remove extension set filtering from the shadow pass (`gen_place_placements`), fixing a correctness bug where `best_possible_equity` was underestimated, causing the pruning in `kurnia_gen_place_moves_iter` to silently skip placements containing the best move in release builds
- Remove all dead extension set code (`gen_extension_sets`, `collect_extension_bits`, four `Box<[u64]>` fields) since extension sets are no longer used anywhere after #25 removed them from word generation

## Root cause
The shadow pass used per-position extension sets to prune which tiles could extend a placement. These sets were computed for the tile group *adjacent to each position*, but the shadow walk could cross through one group while extending from a different anchor. At intermediate positions, the extension set answered the wrong question (e.g., "what extends rightward from S?" when the walk was extending leftward from A).

This is the same fundamental bug as #25 (TENSIONAL regression), but manifesting in the shadow/pruning pass instead of word generation.

## Reproduction
`cargo run --bin leave -- english-compare CSW24.kwg CSW24.klv2 CSW24.klv2 5000 0` triggers `debug_assert` failures in debug builds. Example: JESSAMY down column E hitting DWS at both rows 5 and 11 (word_multiplier=4), but the shadow only reached row 5's DWS (word_multiplier=2) because the extension set at row 11 blocked the walk.

## Test plan
- [x] `debug_assert` in `kurnia_gen_place_moves_iter` passes for 10 seeds × 5000 game pairs (previously failed on 8/10 seeds)
- [x] `cargo test`, `cargo clippy --all-targets`, `cargo build --release` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)