### PR TITLE
remove game pairs from main_auto and starting player randomization

### DIFF
--- a/src/main_auto.rs
+++ b/src/main_auto.rs
@@ -194,7 +194,6 @@ fn do_it<N: kwg::Node>(
     let mut display_scores = vec![0i32; game_state.players.len()];
     loop {
         game_state.reset_and_draw_tiles_double_ended(game_config, &mut rng);
-        game_state.turn = rng.random_range(0..game_config.num_players());
         final_scores.iter_mut().for_each(|s| *s = 0);
         //timers.reset_to(25 * 60 * 1000);
         timers.reset_to(15 * 1000);

--- a/src/main_auto.rs
+++ b/src/main_auto.rs
@@ -190,74 +190,110 @@ fn do_it<N: kwg::Node>(
         }
         return Ok(());
     }
-    let mut saved_game_state = game_state.clone();
     let mut final_scores = vec![0i32; game_state.players.len()];
     let mut display_scores = vec![0i32; game_state.players.len()];
     loop {
         game_state.reset_and_draw_tiles_double_ended(game_config, &mut rng);
-        saved_game_state.clone_from(&game_state);
-        for went_first in 0..2u8 {
-            if went_first > 0 {
-                game_state.clone_from(&saved_game_state);
-            }
-            game_state.turn = went_first;
-            final_scores.iter_mut().for_each(|s| *s = 0);
-            //timers.reset_to(25 * 60 * 1000);
-            timers.reset_to(15 * 1000);
+        game_state.turn = rng.random_range(0..game_config.num_players());
+        final_scores.iter_mut().for_each(|s| *s = 0);
+        //timers.reset_to(25 * 60 * 1000);
+        timers.reset_to(15 * 1000);
 
-            loop {
-                timers.set_turn(game_state.turn as i8);
-                display::print_game_state(game_config, &game_state, Some(&timers));
+        loop {
+            timers.set_turn(game_state.turn as i8);
+            display::print_game_state(game_config, &game_state, Some(&timers));
 
-                if false {
-                    let fen_str = format!(
-                        "{}",
-                        display::BoardFenner::new(
-                            game_config.alphabet(),
-                            game_config.board_layout(),
-                            &game_state.board_tiles,
-                        )
-                    );
-                    println!("{fen_str}");
-                    let parsed_fen = fen_parser.parse(&fen_str)?;
-                    if parsed_fen != &game_state.board_tiles[..] {
-                        println!(
-                            "{} parses into {:?} (expecting {:?})",
-                            fen_str, parsed_fen, game_state.board_tiles
-                        );
-                    }
-                }
-
-                let filtered_movegen = if game_state.turn == 0 {
-                    &mut filtered_movegen_0
-                } else {
-                    &mut filtered_movegen_1
-                };
-                if let move_filter::GenMoves::Tilt { tilt, bot_level } = filtered_movegen {
-                    tilt.tilt_by_rng(&mut rng, *bot_level);
+            if false {
+                let fen_str = format!(
+                    "{}",
+                    display::BoardFenner::new(
+                        game_config.alphabet(),
+                        game_config.board_layout(),
+                        &game_state.board_tiles,
+                    )
+                );
+                println!("{fen_str}");
+                let parsed_fen = fen_parser.parse(&fen_str)?;
+                if parsed_fen != &game_state.board_tiles[..] {
                     println!(
-                        "Effective tilt: tilt factor = {}/{}, leave scale = {}/{}",
-                        tilt.tilt_factor,
-                        move_filter::TILT_DENOM,
-                        tilt.leave_scale,
-                        move_filter::LEAVE_SCALE_DENOM
+                        "{} parses into {:?} (expecting {:?})",
+                        fen_str, parsed_fen, game_state.board_tiles
                     );
                 }
+            }
 
-                let move_picker = if game_state.turn == 0 {
-                    &mut move_picker_0
-                } else {
-                    &mut move_picker_1
-                };
+            let filtered_movegen = if game_state.turn == 0 {
+                &mut filtered_movegen_0
+            } else {
+                &mut filtered_movegen_1
+            };
+            if let move_filter::GenMoves::Tilt { tilt, bot_level } = filtered_movegen {
+                tilt.tilt_by_rng(&mut rng, *bot_level);
+                println!(
+                    "Effective tilt: tilt factor = {}/{}, leave scale = {}/{}",
+                    tilt.tilt_factor,
+                    move_filter::TILT_DENOM,
+                    tilt.leave_scale,
+                    move_filter::LEAVE_SCALE_DENOM
+                );
+            }
 
-                let board_snapshot = &movegen::BoardSnapshot {
-                    board_tiles: &game_state.board_tiles,
-                    game_config,
-                    kwg,
-                    klv,
-                };
+            let move_picker = if game_state.turn == 0 {
+                &mut move_picker_0
+            } else {
+                &mut move_picker_1
+            };
 
-                if false {
+            let board_snapshot = &movegen::BoardSnapshot {
+                board_tiles: &game_state.board_tiles,
+                game_config,
+                kwg,
+                klv,
+            };
+
+            if false {
+                move_generator.gen_moves_unfiltered(&movegen::GenMovesParams {
+                    board_snapshot,
+                    rack: &game_state.current_player().rack,
+                    max_gen: usize::MAX,
+                    num_exchanges_by_this_player: game_state.current_player().num_exchanges,
+                    always_include_pass: false,
+                });
+                // test word prune, only for classic.
+                let plays2;
+                let plays = if match &board_snapshot.game_config.game_rules() {
+                    game_config::GameRules::Classic => true,
+                    game_config::GameRules::Jumbled => false,
+                } {
+                    let plays1 = move_generator.plays.clone();
+                    // these always allocate for now.
+                    let mut set_of_words = fash::MyHashSet::<bites::Bites>::default();
+                    move_generator.gen_remaining_words(board_snapshot, |word: &[u8]| {
+                        set_of_words.insert(word.into());
+                    });
+                    println!("word_prune: {} words", set_of_words.len());
+                    let mut vec_of_words = set_of_words.into_iter().collect::<Vec<_>>();
+                    vec_of_words.sort_unstable();
+                    let smaller_kwg_bytes = build::build(
+                        build::BuildContent::Gaddawg,
+                        build::BuildLayout::Wolges,
+                        &vec_of_words.into_boxed_slice(),
+                    )?;
+                    println!("word_prune: {} bytes kwg", smaller_kwg_bytes.len());
+                    let smaller_kwg = kwg::Kwg::<N>::from_bytes_alloc(&smaller_kwg_bytes);
+                    move_generator.reset_for_another_kwg();
+                    move_generator.gen_moves_unfiltered(&movegen::GenMovesParams {
+                        board_snapshot: &movegen::BoardSnapshot {
+                            kwg: &smaller_kwg,
+                            ..*board_snapshot
+                        },
+                        rack: &game_state.current_player().rack,
+                        max_gen: usize::MAX,
+                        num_exchanges_by_this_player: game_state.current_player().num_exchanges,
+                        always_include_pass: false,
+                    });
+                    plays2 = move_generator.plays.clone();
+                    move_generator.reset_for_another_kwg();
                     move_generator.gen_moves_unfiltered(&movegen::GenMovesParams {
                         board_snapshot,
                         rack: &game_state.current_player().rack,
@@ -265,239 +301,188 @@ fn do_it<N: kwg::Node>(
                         num_exchanges_by_this_player: game_state.current_player().num_exchanges,
                         always_include_pass: false,
                     });
-                    // test word prune, only for classic.
-                    let plays2;
-                    let plays = if match &board_snapshot.game_config.game_rules() {
-                        game_config::GameRules::Classic => true,
-                        game_config::GameRules::Jumbled => false,
-                    } {
-                        let plays1 = move_generator.plays.clone();
-                        // these always allocate for now.
-                        let mut set_of_words = fash::MyHashSet::<bites::Bites>::default();
-                        move_generator.gen_remaining_words(board_snapshot, |word: &[u8]| {
-                            set_of_words.insert(word.into());
-                        });
-                        println!("word_prune: {} words", set_of_words.len());
-                        let mut vec_of_words = set_of_words.into_iter().collect::<Vec<_>>();
-                        vec_of_words.sort_unstable();
-                        let smaller_kwg_bytes = build::build(
-                            build::BuildContent::Gaddawg,
-                            build::BuildLayout::Wolges,
-                            &vec_of_words.into_boxed_slice(),
-                        )?;
-                        println!("word_prune: {} bytes kwg", smaller_kwg_bytes.len());
-                        let smaller_kwg = kwg::Kwg::<N>::from_bytes_alloc(&smaller_kwg_bytes);
-                        move_generator.reset_for_another_kwg();
-                        move_generator.gen_moves_unfiltered(&movegen::GenMovesParams {
-                            board_snapshot: &movegen::BoardSnapshot {
-                                kwg: &smaller_kwg,
-                                ..*board_snapshot
-                            },
-                            rack: &game_state.current_player().rack,
-                            max_gen: usize::MAX,
-                            num_exchanges_by_this_player: game_state.current_player().num_exchanges,
-                            always_include_pass: false,
-                        });
-                        plays2 = move_generator.plays.clone();
-                        move_generator.reset_for_another_kwg();
-                        move_generator.gen_moves_unfiltered(&movegen::GenMovesParams {
-                            board_snapshot,
-                            rack: &game_state.current_player().rack,
-                            max_gen: usize::MAX,
-                            num_exchanges_by_this_player: game_state.current_player().num_exchanges,
-                            always_include_pass: false,
-                        });
-                        if plays1 != move_generator.plays {
-                            panic!("movegen was confused");
-                        }
-                        if plays1 != plays2 {
-                            panic!("movegen cannot work with smaller kwg");
-                        }
-                        &plays2
-                    } else {
-                        &move_generator.plays
-                    };
-                    println!("{} moves found...", plays.len());
-                    for play in plays.iter() {
-                        println!("{} {}", play.equity, play.play.fmt(board_snapshot));
+                    if plays1 != move_generator.plays {
+                        panic!("movegen was confused");
                     }
-                }
-
-                // stress-test scoring algorithm
-                if match &board_snapshot.game_config.game_rules() {
-                    game_config::GameRules::Classic => false,
-                    game_config::GameRules::Jumbled => false,
-                } {
-                    let leave_scale =
-                        if let move_filter::GenMoves::Tilt { tilt, .. } = filtered_movegen {
-                            tilt.leave_scale
-                        } else {
-                            move_filter::LEAVE_SCALE_DENOM
-                        };
-                    move_generator.gen_moves_filtered(
-                        &movegen::GenMovesParams {
-                            board_snapshot,
-                            rack: &game_state.current_player().rack,
-                            max_gen: usize::MAX,
-                            num_exchanges_by_this_player: game_state.current_player().num_exchanges,
-                            always_include_pass: true,
-                        },
-                        |_down: bool, _lane: i8, _idx: i8, _word: &[u8], _score: i32| true,
-                        |leave_value: i32| {
-                            (leave_value as i64 * leave_scale as i64
-                                / move_filter::LEAVE_SCALE_DENOM as i64)
-                                as i32
-                        },
-                        |_equity: equity::Equity, _play: &movegen::Play| true,
-                    );
-                    let plays = &mut move_generator.plays;
-                    println!("{} moves found...", plays.len());
-                    let mut issues = 0;
-                    let mut ps = play_scorer::PlayScorer::new();
-                    for play in plays.iter() {
-                        match ps.validate_play(board_snapshot, &game_state, &play.play) {
-                            Err(err) => {
-                                issues += 1;
-                                println!(
-                                    "{} is not valid, {}!",
-                                    play.play.fmt(board_snapshot),
-                                    err
-                                );
-                            }
-                            Ok(adjusted_play) => {
-                                if let Some(canonical_play) = adjusted_play {
-                                    issues += 1;
-                                    println!(
-                                        "{} is valid, but reformats into {}!",
-                                        play.play.fmt(board_snapshot),
-                                        canonical_play.fmt(board_snapshot)
-                                    );
-                                }
-                                let movegen_score = match &play.play {
-                                    movegen::Play::Exchange { .. } => 0,
-                                    movegen::Play::Place { score, .. } => *score,
-                                };
-                                let recounted_score = ps.compute_score(board_snapshot, &play.play);
-                                if movegen_score != recounted_score {
-                                    issues += 1;
-                                    println!(
-                                        "{} should score {} instead of {}!",
-                                        play.play.fmt(board_snapshot),
-                                        recounted_score,
-                                        movegen_score
-                                    );
-                                } else {
-                                    let recounted_equity = ps.compute_equity(
-                                        board_snapshot,
-                                        &game_state,
-                                        &play.play,
-                                        leave_scale,
-                                        recounted_score,
-                                    );
-                                    if play.equity.raw() != recounted_equity {
-                                        issues += 1;
-                                        println!(
-                                            "{} should have equity {} instead of {}!",
-                                            play.play.fmt(board_snapshot),
-                                            equity::Equity::new(recounted_equity),
-                                            play.equity
-                                        );
-                                    }
-                                }
-                                if !ps.words_are_valid(board_snapshot, &play.play) {
-                                    issues += 1;
-                                    println!(
-                                        "{} forms invalid words!",
-                                        play.play.fmt(board_snapshot)
-                                    );
-                                }
-                            }
-                        }
+                    if plays1 != plays2 {
+                        panic!("movegen cannot work with smaller kwg");
                     }
-                    assert_eq!(issues, 0);
+                    &plays2
+                } else {
+                    &move_generator.plays
+                };
+                println!("{} moves found...", plays.len());
+                for play in plays.iter() {
+                    println!("{} {}", play.equity, play.play.fmt(board_snapshot));
                 }
+            }
 
-                if false {
-                    // not required for now.
-                    move_generator.reset_for_another_kwg();
-                }
-                move_picker.pick_a_move(
-                    filtered_movegen,
-                    &mut move_generator,
-                    board_snapshot,
-                    &game_state,
-                    &game_state.current_player().rack,
+            // stress-test scoring algorithm
+            if match &board_snapshot.game_config.game_rules() {
+                game_config::GameRules::Classic => false,
+                game_config::GameRules::Jumbled => false,
+            } {
+                let leave_scale = if let move_filter::GenMoves::Tilt { tilt, .. } = filtered_movegen
+                {
+                    tilt.leave_scale
+                } else {
+                    move_filter::LEAVE_SCALE_DENOM
+                };
+                move_generator.gen_moves_filtered(
+                    &movegen::GenMovesParams {
+                        board_snapshot,
+                        rack: &game_state.current_player().rack,
+                        max_gen: usize::MAX,
+                        num_exchanges_by_this_player: game_state.current_player().num_exchanges,
+                        always_include_pass: true,
+                    },
+                    |_down: bool, _lane: i8, _idx: i8, _word: &[u8], _score: i32| true,
+                    |leave_value: i32| {
+                        (leave_value as i64 * leave_scale as i64
+                            / move_filter::LEAVE_SCALE_DENOM as i64) as i32
+                    },
+                    |_equity: equity::Equity, _play: &movegen::Play| true,
                 );
                 let plays = &mut move_generator.plays;
-                let play = &plays[0].play; // assume at least there's always Pass
-                println!("Playing: {}", play.fmt(board_snapshot));
-
-                game_state.play(game_config, &mut rng, play)?;
-
-                match game_state.check_game_ended(game_config, &mut final_scores) {
-                    game_state::CheckGameEnded::PlayedOut => {
-                        println!("Player {} went out", game_state.turn + 1);
-                        break;
+                println!("{} moves found...", plays.len());
+                let mut issues = 0;
+                let mut ps = play_scorer::PlayScorer::new();
+                for play in plays.iter() {
+                    match ps.validate_play(board_snapshot, &game_state, &play.play) {
+                        Err(err) => {
+                            issues += 1;
+                            println!("{} is not valid, {}!", play.play.fmt(board_snapshot), err);
+                        }
+                        Ok(adjusted_play) => {
+                            if let Some(canonical_play) = adjusted_play {
+                                issues += 1;
+                                println!(
+                                    "{} is valid, but reformats into {}!",
+                                    play.play.fmt(board_snapshot),
+                                    canonical_play.fmt(board_snapshot)
+                                );
+                            }
+                            let movegen_score = match &play.play {
+                                movegen::Play::Exchange { .. } => 0,
+                                movegen::Play::Place { score, .. } => *score,
+                            };
+                            let recounted_score = ps.compute_score(board_snapshot, &play.play);
+                            if movegen_score != recounted_score {
+                                issues += 1;
+                                println!(
+                                    "{} should score {} instead of {}!",
+                                    play.play.fmt(board_snapshot),
+                                    recounted_score,
+                                    movegen_score
+                                );
+                            } else {
+                                let recounted_equity = ps.compute_equity(
+                                    board_snapshot,
+                                    &game_state,
+                                    &play.play,
+                                    leave_scale,
+                                    recounted_score,
+                                );
+                                if play.equity.raw() != recounted_equity {
+                                    issues += 1;
+                                    println!(
+                                        "{} should have equity {} instead of {}!",
+                                        play.play.fmt(board_snapshot),
+                                        equity::Equity::new(recounted_equity),
+                                        play.equity
+                                    );
+                                }
+                            }
+                            if !ps.words_are_valid(board_snapshot, &play.play) {
+                                issues += 1;
+                                println!("{} forms invalid words!", play.play.fmt(board_snapshot));
+                            }
+                        }
                     }
-                    game_state::CheckGameEnded::ZeroScores => {
-                        println!(
-                            "Player {} ended game by making yet another zero score",
-                            game_state.turn + 1
-                        );
-                        break;
-                    }
-                    game_state::CheckGameEnded::NotEnded => {}
                 }
-                game_state.next_turn();
+                assert_eq!(issues, 0);
             }
-            timers.set_turn(-1);
 
-            display::print_game_state(game_config, &game_state, Some(&timers));
+            if false {
+                // not required for now.
+                move_generator.reset_for_another_kwg();
+            }
+            move_picker.pick_a_move(
+                filtered_movegen,
+                &mut move_generator,
+                board_snapshot,
+                &game_state,
+                &game_state.current_player().rack,
+            );
+            let plays = &mut move_generator.plays;
+            let play = &plays[0].play; // assume at least there's always Pass
+            println!("Playing: {}", play.fmt(board_snapshot));
+
+            game_state.play(game_config, &mut rng, play)?;
+
+            match game_state.check_game_ended(game_config, &mut final_scores) {
+                game_state::CheckGameEnded::PlayedOut => {
+                    println!("Player {} went out", game_state.turn + 1);
+                    break;
+                }
+                game_state::CheckGameEnded::ZeroScores => {
+                    println!(
+                        "Player {} ended game by making yet another zero score",
+                        game_state.turn + 1
+                    );
+                    break;
+                }
+                game_state::CheckGameEnded::NotEnded => {}
+            }
+            game_state.next_turn();
+        }
+        timers.set_turn(-1);
+
+        display::print_game_state(game_config, &game_state, Some(&timers));
+        for (d, &f) in display_scores.iter_mut().zip(final_scores.iter()) {
+            *d = f / equity::SCALE;
+        }
+        println!("Final scores: {display_scores:?}");
+        let mut has_time_adjustment = false;
+        for (i, &clock_ms) in timers.clocks_ms.iter().enumerate() {
+            let adjustment = game_config.time_adjustment(clock_ms);
+            if adjustment != 0 {
+                println!("Player {} adjustment {}", i + 1, adjustment);
+                final_scores[i] += adjustment as i32 * equity::SCALE;
+                has_time_adjustment = true;
+            }
+        }
+        if has_time_adjustment {
             for (d, &f) in display_scores.iter_mut().zip(final_scores.iter()) {
                 *d = f / equity::SCALE;
             }
-            println!("Final scores: {display_scores:?}");
-            let mut has_time_adjustment = false;
-            for (i, &clock_ms) in timers.clocks_ms.iter().enumerate() {
-                let adjustment = game_config.time_adjustment(clock_ms);
-                if adjustment != 0 {
-                    println!("Player {} adjustment {}", i + 1, adjustment);
-                    final_scores[i] += adjustment as i32 * equity::SCALE;
-                    has_time_adjustment = true;
-                }
-            }
-            if has_time_adjustment {
-                for (d, &f) in display_scores.iter_mut().zip(final_scores.iter()) {
-                    *d = f / equity::SCALE;
-                }
-                println!("Really final scores: {display_scores:?}");
-            }
+            println!("Really final scores: {display_scores:?}");
+        }
 
-            let spr = display_scores[0] - display_scores[1];
-            let p0dw = spr.signum() + 1; // double win
-            score_stats_0.update(display_scores[0] as f64);
-            score_stats_1.update(display_scores[1] as f64);
-            spread_stats_0.update(spr as f64);
-            win_stats_0.update(p0dw as f64 * 50.0);
-            loss_draw_win[p0dw as usize] += 1;
+        let spr = display_scores[0] - display_scores[1];
+        let p0dw = spr.signum() + 1; // double win
+        score_stats_0.update(display_scores[0] as f64);
+        score_stats_1.update(display_scores[1] as f64);
+        spread_stats_0.update(spr as f64);
+        win_stats_0.update(p0dw as f64 * 50.0);
+        loss_draw_win[p0dw as usize] += 1;
 
-            println!(
-                "Stats: {display_scores:?} n={} ({}-{}-{}) p0={:.3} (sd={:.3}) p1={:.3} (sd={:.3}) p0-p1={:.3} (sd={:.3}) p0w={:.3} (sd={:.3})",
-                loss_draw_win[0] + loss_draw_win[1] + loss_draw_win[2],
-                loss_draw_win[2],
-                loss_draw_win[0],
-                loss_draw_win[1],
-                score_stats_0.mean(),
-                score_stats_0.standard_deviation(),
-                score_stats_1.mean(),
-                score_stats_1.standard_deviation(),
-                spread_stats_0.mean(),
-                spread_stats_0.standard_deviation(),
-                win_stats_0.mean(),
-                win_stats_0.standard_deviation(),
-            );
-        } // for went_first
-    } // temp loop
+        println!(
+            "Stats: {display_scores:?} n={} ({}-{}-{}) p0={:.3} (sd={:.3}) p1={:.3} (sd={:.3}) p0-p1={:.3} (sd={:.3}) p0w={:.3} (sd={:.3})",
+            loss_draw_win[0] + loss_draw_win[1] + loss_draw_win[2],
+            loss_draw_win[2],
+            loss_draw_win[0],
+            loss_draw_win[1],
+            score_stats_0.mean(),
+            score_stats_0.standard_deviation(),
+            score_stats_1.mean(),
+            score_stats_1.standard_deviation(),
+            spread_stats_0.mean(),
+            spread_stats_0.standard_deviation(),
+            win_stats_0.mean(),
+            win_stats_0.standard_deviation(),
+        );
+    } // loop
 
     //Ok(())
 }

--- a/src/main_leave.rs
+++ b/src/main_leave.rs
@@ -920,9 +920,7 @@ fn generate_autoplay_logs<
                         game_id.push(BASE62[(num_prior_games / (62 * 62) % 62) as usize] as char);
                         game_id.push(BASE62[(num_prior_games / 62 % 62) as usize] as char);
                         game_id.push(BASE62[(num_prior_games % 62) as usize] as char);
-                        let went_first = rng.random_range(0..game_config.num_players());
                         game_state.reset_and_draw_tiles_double_ended(&game_config, &mut rng);
-                        game_state.turn = went_first;
                         loop {
                             num_moves += 1;
 
@@ -1231,7 +1229,7 @@ fn generate_autoplay_logs<
                                             &final_scores,
                                             &num_bingos,
                                             &num_turns,
-                                            &player_aliases[went_first as usize],
+                                            &player_aliases[0],
                                         ))
                                         .unwrap();
                                     num_batched_games_here += 1;

--- a/src/main_leave.rs
+++ b/src/main_leave.rs
@@ -2470,7 +2470,6 @@ fn compare_leaves<N: kwg::Node + Sync + Send, L: kwg::Node + Sync + Send>(
                     game_state.reset_and_draw_tiles_double_ended(&game_config, &mut rng);
                     saved_game_state.clone_from(&game_state);
                     let saved_rng_state = rng.serialize_state();
-                    let starting_player = (pair_idx % 2) as u8;
 
                     let mut pair_diverged = false;
                     let mut pair_results =
@@ -2481,7 +2480,6 @@ fn compare_leaves<N: kwg::Node + Sync + Send, L: kwg::Node + Sync + Send>(
                             game_state.clone_from(&saved_game_state);
                             rng = rand::rngs::ChaCha20Rng::deserialize_state(&saved_rng_state);
                         }
-                        game_state.turn = starting_player;
                         let klv_swapped = game_in_pair != 0;
                         let mut num_turns = 0u32;
                         if !klv_swapped {


### PR DESCRIPTION
## Summary
- Revert game pairs in main_auto (reverts 5c8f93ac) — game pairs are for comparing leaves, not interactive play/sim
- Remove starting player randomization from main_leave autoplay and main_auto
- Remove starting player alternation from main_leave compare

p0 always starts in all game loops. In compare, symmetry comes from swapping the klv assignment within each pair, not from alternating starting player.

## Test plan
- [x] Same-klv compare gives exactly 50/50 results
- [x] `cargo fmt`, `cargo clippy --all-targets`, `cargo test` all pass