### PR TITLE
deterministic seeded compare via per-pair streams + canonical bag reset

### DIFF
--- a/src/bag.rs
+++ b/src/bag.rs
@@ -6,6 +6,7 @@ use rand::prelude::*;
 pub struct Bag {
     tiles: Vec<u8>,
     fc: usize, // front cursor: tiles[0..fc] is dead space, tiles[fc..] is playable
+    canonical: Box<[u8]>, // initial tile sequence, for zero-alloc reset
 }
 
 impl Bag {
@@ -19,7 +20,18 @@ impl Bag {
                 tiles.push(tile);
             }
         }
-        Bag { tiles, fc: 0 }
+        let canonical = tiles.clone().into_boxed_slice();
+        Bag {
+            tiles,
+            fc: 0,
+            canonical,
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.tiles.clear();
+        self.fc = 0;
+        self.tiles.extend_from_slice(&self.canonical);
     }
 
     pub fn shuffle(&mut self, mut rng: &mut dyn Rng) {
@@ -256,6 +268,7 @@ impl Clone for Bag {
         Self {
             tiles: self.tiles.clone(),
             fc: self.fc,
+            canonical: self.canonical.clone(),
         }
     }
 
@@ -263,5 +276,6 @@ impl Clone for Bag {
     fn clone_from(&mut self, source: &Self) {
         self.tiles.clone_from(&source.tiles);
         self.fc = source.fc;
+        self.canonical.clone_from(&source.canonical);
     }
 }

--- a/src/bag.rs
+++ b/src/bag.rs
@@ -88,12 +88,19 @@ impl Bag {
         }
     }
 
-    pub fn return_tiles(&mut self, tiles: &[u8]) {
-        self.tiles.extend_from_slice(tiles);
+    pub fn return_tile(&mut self, tile: u8) {
+        if self.fc > 0 {
+            self.fc -= 1;
+            self.tiles[self.fc] = tile;
+        } else {
+            self.tiles.push(tile);
+        }
     }
 
-    pub fn return_tile(&mut self, tile: u8) {
-        self.tiles.push(tile);
+    pub fn return_tiles(&mut self, tiles: &[u8]) {
+        for &tile in tiles {
+            self.return_tile(tile);
+        }
     }
 
     pub fn set_from_iter<I: IntoIterator<Item = u8>>(&mut self, iter: I) {

--- a/src/game_state.rs
+++ b/src/game_state.rs
@@ -97,14 +97,11 @@ impl GameState {
     pub fn reset(&mut self) {
         for player in self.players.iter_mut() {
             player.score = 0;
-            self.bag.return_tiles(&player.rack);
             player.rack.clear();
             player.num_exchanges = 0;
         }
-        for &tile in self.board_tiles.iter().filter(|&&tile| tile != 0) {
-            self.bag.return_tile(tile & !((tile as i8) >> 7) as u8);
-        }
         self.board_tiles.iter_mut().for_each(|m| *m = 0);
+        self.bag.reset();
         self.turn = 0;
         self.zero_turns = 0;
         self.pass_turns = 0;

--- a/src/main_leave.rs
+++ b/src/main_leave.rs
@@ -2433,7 +2433,9 @@ fn compare_leaves<N: kwg::Node + Sync + Send, L: kwg::Node + Sync + Send>(
 ) -> error::Returns<()> {
     let game_config = std::sync::Arc::new(game_config);
     let kwg = std::sync::Arc::new(kwg);
-    let num_threads = if seed.is_some() { 1 } else { num_cpus::get() };
+    let seed = seed.unwrap_or_else(rand::random);
+    eprintln!("seed: {seed}");
+    let num_threads = num_cpus::get();
     let completed_pairs = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
     let reported_secs = std::sync::atomic::AtomicU64::new(0);
     let t0 = std::time::Instant::now();
@@ -2448,11 +2450,7 @@ fn compare_leaves<N: kwg::Node + Sync + Send, L: kwg::Node + Sync + Send>(
             let completed_pairs = std::sync::Arc::clone(&completed_pairs);
             let reported_secs = &reported_secs;
             thread_handles.push(s.spawn(move || {
-                let mut rng = if let Some(seed) = seed {
-                    rand::rngs::ChaCha20Rng::seed_from_u64(seed)
-                } else {
-                    rand::rngs::ChaCha20Rng::try_from_rng(&mut rand::rngs::SysRng).unwrap()
-                };
+                let mut rng = rand::rngs::ChaCha20Rng::seed_from_u64(seed);
                 let mut move_generator = movegen::KurniaMoveGenerator::new(&game_config);
                 let mut game_state = game_state::GameState::new(&game_config);
                 let mut saved_game_state = game_state.clone();
@@ -2467,6 +2465,7 @@ fn compare_leaves<N: kwg::Node + Sync + Send, L: kwg::Node + Sync + Send>(
                         break;
                     }
 
+                    rng.set_stream(pair_idx);
                     game_state.reset_and_draw_tiles_double_ended(&game_config, &mut rng);
                     saved_game_state.clone_from(&game_state);
                     let saved_rng_state = rng.serialize_state();


### PR DESCRIPTION
## Summary
- `Bag::new()` stores canonical tile sequence (`Box<[u8]>`); `Bag::reset()` restores it without allocation
- `GameState::reset()` calls `Bag::reset()` instead of returning tiles one by one (which left them in game-dependent order → different shuffle across threads)
- `compare` always multi-threaded; each pair uses `ChaCha20Rng::set_stream(pair_idx)` for independent deterministic streams
- Unseeded runs generate a random seed and print it to stderr (reproducible by passing the seed back)
- `Bag::return_tile` reuses front dead space before extending the Vec (fixes unbounded growth when `pop_front` and `return_tile` interleave across games)

## Test plan
- [x] Seeded compare with different KLVs: 3 runs, byte-identical wins/losses/draws (95/104/1)
- [x] Same-KLV compare: exactly 50/50 (game pair symmetry verified)
- [x] `cargo fmt --check`, `cargo clippy --all-targets`, `cargo build --release`, `cargo test` all pass on each commit