### PR TITLE
use per-game stream seeding in autoplay and playability

### DIFF
--- a/src/main_leave.rs
+++ b/src/main_leave.rs
@@ -365,6 +365,11 @@ fn do_lang_kwg<GameConfigMaker: Fn() -> game_config::GameConfig, N: kwg::Node + 
                 } else {
                     1_000_000
                 };
+                let seed = if args.len() > 5 {
+                    Some(u64::from_str(&args[5])?)
+                } else {
+                    None
+                };
                 let kwg =
                     kwg::Kwg::<N>::from_bytes_alloc(&read_to_end(&mut make_reader(&args[2])?)?);
                 let klv = if args3 == "-" {
@@ -372,7 +377,7 @@ fn do_lang_kwg<GameConfigMaker: Fn() -> game_config::GameConfig, N: kwg::Node + 
                 } else {
                     klv::Klv::<kwg::Node22>::from_bytes_alloc(&std::fs::read(args3)?)
                 };
-                discover_playability(make_game_config(), kwg, klv, num_games)?;
+                discover_playability(make_game_config(), kwg, klv, num_games, seed)?;
                 Ok(true)
             }
             _ => Ok(false),
@@ -411,9 +416,10 @@ fn main() -> error::Returns<()> {
     generate leaves (no smoothing) up to rack_size
   english-generate-full summary.csv leaves.csv
     generate leaves (with smoothing) up to rack_size
-  english-playability CSW24.kwg leave.klv 1000000
+  english-playability CSW24.kwg leave.klv 1000000 [seed]
     autoplay (not saved) and record prorated found best words (at the end)
     (run fewer number of games and use resummarize to merge to mitigate risks)
+    seed is optional; prints auto-generated seed to stderr if not provided.
   english-resummarize-playability concatenated_playabilities.csv playability.csv
     same as english-resummarize but sorts differently (by length first)
   english-resummarize-playability-all concat_playabilities.csv playability.csv
@@ -1898,10 +1904,13 @@ fn discover_playability<N: kwg::Node + Sync + Send, L: kwg::Node + Sync + Send>(
     kwg: kwg::Kwg<N>,
     klv: klv::Klv<L>,
     num_games: u64,
+    seed: Option<u64>,
 ) -> error::Returns<()> {
     let game_config = std::sync::Arc::new(game_config);
     let kwg = std::sync::Arc::new(kwg);
     let klv = std::sync::Arc::new(klv);
+    let seed = seed.unwrap_or_else(rand::random);
+    eprintln!("seed: {seed}");
     let num_threads = num_cpus::get();
     let num_processed_games = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
 
@@ -1944,8 +1953,8 @@ fn discover_playability<N: kwg::Node + Sync + Send, L: kwg::Node + Sync + Send>(
             let completed_moves = std::sync::Arc::clone(&completed_moves);
             let mutexed_stuffs = std::sync::Arc::clone(&mutexed_stuffs);
             threads.push(s.spawn(move || {
-                RNG.with(|rng| {
-                    let mut rng = &mut *rng.borrow_mut();
+                {
+                    let mut rng = rand::rngs::ChaCha20Rng::seed_from_u64(seed);
                     let mut move_generator = movegen::KurniaMoveGenerator::new(&game_config);
                     let mut game_state = game_state::GameState::new(&game_config);
                     let mut final_scores = vec![0; game_config.num_players() as usize];
@@ -1993,6 +2002,7 @@ fn discover_playability<N: kwg::Node + Sync + Send, L: kwg::Node + Sync + Send>(
                             num_processed_games.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
                             break;
                         }
+                        rng.set_stream(num_prior_games);
 
                         game_state.reset_and_draw_tiles_double_ended(&game_config, &mut rng);
                         loop {
@@ -2183,7 +2193,7 @@ fn discover_playability<N: kwg::Node + Sync + Send, L: kwg::Node + Sync + Send>(
                                 .or_insert(thread_v);
                         }
                     }
-                })
+                }
             }));
         }
 

--- a/src/main_leave.rs
+++ b/src/main_leave.rs
@@ -394,7 +394,7 @@ fn main() -> error::Returns<()> {
     if leave is \"-\" or omitted, uses no leave.
     number of games is optional.
     min samples per rack is optional, but must be 0 for non-summarize.
-    seed is optional; if provided, uses single thread for reproducibility.
+    seed is optional; prints auto-generated seed to stderr if not provided.
   english-autoplay-summarize CSW24.kwg leave0.klv leave1.klv 1000000 0 [seed]
     same as english-autoplay and also save summary file.
   english-autoplay-summarize-only CSW24.kwg leave0.klv leave1.klv 1000000 0 [seed]
@@ -567,7 +567,9 @@ fn generate_autoplay_logs<
             .map(|x| format!("p{x}"))
             .collect::<Box<[String]>>(),
     );
-    let num_threads = if seed.is_some() { 1 } else { num_cpus::get() };
+    let seed = seed.unwrap_or_else(rand::random);
+    eprintln!("seed: {seed}");
+    let num_threads = num_cpus::get();
     let num_processed_games = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
 
     let epoch_secs = std::time::SystemTime::now()
@@ -689,13 +691,8 @@ fn generate_autoplay_logs<
                 std::sync::Arc::clone(&undersampling_remediation_generation_id);
             let mutexed_stuffs = std::sync::Arc::clone(&mutexed_stuffs);
             threads.push(s.spawn(move || {
-                RNG.with(|rng| {
-                    if let Some(seed) = seed {
-                        *rng.borrow_mut() = Box::new(
-                            rand::rngs::ChaCha20Rng::seed_from_u64(seed),
-                        );
-                    }
-                    let mut rng = &mut *rng.borrow_mut();
+                {
+                    let mut rng = rand::rngs::ChaCha20Rng::seed_from_u64(seed);
                     let mut game_id = String::with_capacity(8);
                     let mut move_generator = movegen::KurniaMoveGenerator::new(&game_config);
                     let mut game_state = game_state::GameState::new(&game_config);
@@ -741,6 +738,7 @@ fn generate_autoplay_logs<
                     loop {
                         let mut num_prior_games =
                             num_processed_games.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        rng.set_stream(num_prior_games);
                         if num_prior_games >= num_games {
                             if !undersampling_remediation_thread_begun {
                                 // first time this thread transitions past the first num_games games.
@@ -1332,7 +1330,7 @@ fn generate_autoplay_logs<
                             }
                         }
                     }
-                })
+                }
             }));
         }
 

--- a/src/main_leave.rs
+++ b/src/main_leave.rs
@@ -9,12 +9,6 @@ use wolges::{
     move_picker, movegen, prob, stats,
 };
 
-thread_local! {
-    static RNG: std::cell::RefCell<Box<dyn rand::Rng>> = std::cell::RefCell::new(Box::new(
-        rand::rngs::ChaCha20Rng::try_from_rng(&mut rand::rngs::SysRng).unwrap(),
-    ));
-}
-
 static BASE62: &[u8; 62] = b"\
 0123456789\
 ABCDEFGHIJKLMNOPQRSTUVWXYZ\

--- a/src/main_leave.rs
+++ b/src/main_leave.rs
@@ -691,135 +691,57 @@ fn generate_autoplay_logs<
                 std::sync::Arc::clone(&undersampling_remediation_generation_id);
             let mutexed_stuffs = std::sync::Arc::clone(&mutexed_stuffs);
             threads.push(s.spawn(move || {
-                {
-                    let mut rng = rand::rngs::ChaCha20Rng::seed_from_u64(seed);
-                    let mut game_id = String::with_capacity(8);
-                    let mut move_generator = movegen::KurniaMoveGenerator::new(&game_config);
-                    let mut game_state = game_state::GameState::new(&game_config);
-                    let mut cur_rack_as_vec = if SUMMARIZE {
-                        Vec::with_capacity(game_config.rack_size() as usize)
-                    } else {
-                        Vec::new()
-                    };
-                    let mut cur_rack_ser = String::new();
-                    let mut aft_rack = Vec::with_capacity(game_config.rack_size() as usize);
-                    let mut aft_rack_ser = String::new();
-                    let mut play_fmt = String::new();
-                    let mut equity_fmt = String::new();
-                    let mut final_scores = vec![0; game_config.num_players() as usize];
-                    let mut num_bingos = vec![0; game_config.num_players() as usize];
-                    let mut num_turns = vec![0; game_config.num_players() as usize];
-                    let mut num_moves;
-                    let mut num_batched_games_here = 0;
-                    let mut batched_csv_log = csv::Writer::from_writer(Vec::new());
-                    let mut batched_csv_game = csv::Writer::from_writer(Vec::new());
-                    let mut thread_full_rack_map =
-                        fash::MyHashMap::<bites::Bites, Cumulate>::default();
-                    let mut exchange_buffer = if SUMMARIZE && min_samples_per_rack != 0 {
-                        Vec::with_capacity(game_config.rack_size() as usize)
-                    } else {
-                        Vec::new()
-                    };
-                    let mut alphabet_freqs = if SUMMARIZE && min_samples_per_rack != 0 {
-                        (0..game_config.alphabet().len())
-                            .map(|tile| game_config.alphabet().freq(tile))
-                            .collect::<Vec<_>>()
-                    } else {
-                        Vec::new()
-                    };
-                    let mut unseen_tally = if SUMMARIZE && min_samples_per_rack != 0 {
-                        vec![0u8; game_config.alphabet().len() as usize]
-                    } else {
-                        Vec::new()
-                    };
-                    let mut undersampled_thread_racks = Vec::<bites::Bites>::new();
-                    let mut undersampling_remediation_thread_generation_id = 0;
-                    let mut undersampling_remediation_thread_begun = false;
-                    loop {
-                        let mut num_prior_games =
-                            num_processed_games.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                        rng.set_stream(num_prior_games);
-                        if num_prior_games >= num_games {
-                            if !undersampling_remediation_thread_begun {
-                                // first time this thread transitions past the first num_games games.
-                                {
-                                    let mut mutex_guard = mutexed_stuffs.lock().unwrap();
-                                    for (k, thread_v) in thread_full_rack_map.iter() {
-                                        if thread_v.count > 0 {
-                                            mutex_guard
-                                                .full_rack_map
-                                                .entry(k[..].into())
-                                                .and_modify(|v| {
-                                                    v.equity += thread_v.equity;
-                                                    v.count += thread_v.count;
-                                                })
-                                                .or_insert(thread_v.clone());
-                                        }
-                                    }
-                                    thread_full_rack_map.clear();
-                                }
-                                undersampling_remediation_submission
-                                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                                // wait until all threads rendezvous here.
-                                while undersampling_remediation_submission
-                                    .load(std::sync::atomic::Ordering::Relaxed)
-                                    != num_threads as u64
-                                {}
-                                match undersampling_remediation_state.compare_exchange(
-                                    0,
-                                    1,
-                                    std::sync::atomic::Ordering::Relaxed,
-                                    std::sync::atomic::Ordering::Relaxed,
-                                ) {
-                                    Ok(_) => {
-                                        // this thread is responsible to iterate the possible racks.
-                                        {
-                                            let mut mutex_guard = mutexed_stuffs.lock().unwrap();
-                                            std::mem::swap(
-                                                &mut thread_full_rack_map,
-                                                &mut mutex_guard.full_rack_map,
-                                            );
-                                            generate_exchanges(&mut ExchangeEnv {
-                                                found_exchange_move: |rack_bytes: &[u8]| {
-                                                    let rack_freq = thread_full_rack_map
-                                                        .get(rack_bytes)
-                                                        .map_or(0, |v| v.count);
-                                                    if rack_freq < min_samples_per_rack {
-                                                        mutex_guard
-                                                            .undersampled_racks
-                                                            .push(rack_bytes.into());
-                                                    }
-                                                },
-                                                rack_tally: &mut alphabet_freqs,
-                                                min_len: game_config.rack_size(),
-                                                max_len: game_config.rack_size(),
-                                                exchange_buffer: &mut exchange_buffer,
-                                            });
-                                            std::mem::swap(
-                                                &mut thread_full_rack_map,
-                                                &mut mutex_guard.full_rack_map,
-                                            );
-                                        }
-                                        undersampling_remediation_state
-                                            .compare_exchange(
-                                                1,
-                                                2,
-                                                std::sync::atomic::Ordering::Relaxed,
-                                                std::sync::atomic::Ordering::Relaxed,
-                                            )
-                                            .unwrap();
-                                    }
-                                    Err(_) => {
-                                        // another thread is contemporaneously iterating the possible racks.
-                                        while undersampling_remediation_state
-                                            .load(std::sync::atomic::Ordering::Relaxed)
-                                            <= 1
-                                        {}
-                                    }
-                                }
-                                undersampling_remediation_thread_begun = true;
-                            }
-                            if undersampled_thread_racks.is_empty() {
+                let mut rng = rand::rngs::ChaCha20Rng::seed_from_u64(seed);
+                let mut game_id = String::with_capacity(8);
+                let mut move_generator = movegen::KurniaMoveGenerator::new(&game_config);
+                let mut game_state = game_state::GameState::new(&game_config);
+                let mut cur_rack_as_vec = if SUMMARIZE {
+                    Vec::with_capacity(game_config.rack_size() as usize)
+                } else {
+                    Vec::new()
+                };
+                let mut cur_rack_ser = String::new();
+                let mut aft_rack = Vec::with_capacity(game_config.rack_size() as usize);
+                let mut aft_rack_ser = String::new();
+                let mut play_fmt = String::new();
+                let mut equity_fmt = String::new();
+                let mut final_scores = vec![0; game_config.num_players() as usize];
+                let mut num_bingos = vec![0; game_config.num_players() as usize];
+                let mut num_turns = vec![0; game_config.num_players() as usize];
+                let mut num_moves;
+                let mut num_batched_games_here = 0;
+                let mut batched_csv_log = csv::Writer::from_writer(Vec::new());
+                let mut batched_csv_game = csv::Writer::from_writer(Vec::new());
+                let mut thread_full_rack_map =
+                    fash::MyHashMap::<bites::Bites, Cumulate>::default();
+                let mut exchange_buffer = if SUMMARIZE && min_samples_per_rack != 0 {
+                    Vec::with_capacity(game_config.rack_size() as usize)
+                } else {
+                    Vec::new()
+                };
+                let mut alphabet_freqs = if SUMMARIZE && min_samples_per_rack != 0 {
+                    (0..game_config.alphabet().len())
+                        .map(|tile| game_config.alphabet().freq(tile))
+                        .collect::<Vec<_>>()
+                } else {
+                    Vec::new()
+                };
+                let mut unseen_tally = if SUMMARIZE && min_samples_per_rack != 0 {
+                    vec![0u8; game_config.alphabet().len() as usize]
+                } else {
+                    Vec::new()
+                };
+                let mut undersampled_thread_racks = Vec::<bites::Bites>::new();
+                let mut undersampling_remediation_thread_generation_id = 0;
+                let mut undersampling_remediation_thread_begun = false;
+                loop {
+                    let mut num_prior_games =
+                        num_processed_games.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    rng.set_stream(num_prior_games);
+                    if num_prior_games >= num_games {
+                        if !undersampling_remediation_thread_begun {
+                            // first time this thread transitions past the first num_games games.
+                            {
                                 let mut mutex_guard = mutexed_stuffs.lock().unwrap();
                                 for (k, thread_v) in thread_full_rack_map.iter() {
                                     if thread_v.count > 0 {
@@ -834,340 +756,252 @@ fn generate_autoplay_logs<
                                     }
                                 }
                                 thread_full_rack_map.clear();
-                                // this part does not take into account work already done by other threads.
-                                let mut num_moves_to_force = 0u64;
-                                std::mem::swap(
-                                    &mut thread_full_rack_map,
-                                    &mut mutex_guard.full_rack_map,
-                                );
-                                mutex_guard.undersampled_racks.retain(
-                                    |rack_bytes: &bites::Bites| {
-                                        let rack_freq = thread_full_rack_map
-                                            .get(rack_bytes)
-                                            .map_or(0, |v| v.count);
-                                        if rack_freq < min_samples_per_rack {
-                                            num_moves_to_force += min_samples_per_rack - rack_freq;
-                                            true
-                                        } else {
-                                            false
-                                        }
-                                    },
-                                );
-                                std::mem::swap(
-                                    &mut thread_full_rack_map,
-                                    &mut mutex_guard.full_rack_map,
-                                );
-                                undersampled_thread_racks
-                                    .clone_from(&mutex_guard.undersampled_racks);
-                                mutex_guard.undersampling_comment.clear();
-                                if num_moves_to_force != 0 {
-                                    let num_undersampled_racks =
-                                        mutex_guard.undersampled_racks.len();
-                                    write!(
-                                        mutex_guard.undersampling_comment,
-                                        " (need to force {num_undersampled_racks} racks over {num_moves_to_force} moves)"
-                                    )
-                                    .unwrap();
-                                }
-                                undersampling_remediation_countdown.store(
-                                    num_moves_to_force as i64,
-                                    std::sync::atomic::Ordering::Relaxed,
-                                );
-
-                                if undersampled_thread_racks.is_empty() {
-                                    // really done. this thread need not play more games.
-                                    num_processed_games
-                                        .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
-                                    break;
-                                }
-
-                                // if there are too few unique racks, repeat them.
-                                // oversampling is better than locking up mutex.
-                                // use floor division to find the ideal number.
-                                let ideal_number_of_undersampled_thread_racks = (num_threads * 32)
-                                    / undersampled_thread_racks.len()
-                                    * undersampled_thread_racks.len();
-
-                                // if there are too many unique racks, this no-ops.
-                                // the ideal number would be zero but this is fine.
-                                while undersampled_thread_racks.len()
-                                    < ideal_number_of_undersampled_thread_racks
-                                {
-                                    undersampled_thread_racks.extend_from_within(
-                                        ..undersampled_thread_racks.len().min(
-                                            ideal_number_of_undersampled_thread_racks
-                                                - undersampled_thread_racks.len(),
-                                        ),
-                                    );
-                                }
                             }
-                        }
-
-                        num_moves = 0;
-                        num_bingos.iter_mut().for_each(|m| *m = 0);
-                        num_turns.iter_mut().for_each(|m| *m = 0);
-                        game_id.clear();
-                        // random prefix. 62 ** 4 == 14776336, hopefully enough entropy.
-                        for _ in 0..4 {
-                            game_id.push(*BASE62.choose(&mut rng).unwrap() as char);
-                        }
-                        // wrapping sequence number. 62 ** 4 == 14776336.
-                        num_prior_games = num_prior_games.wrapping_add(1);
-                        game_id
-                            .push(BASE62[(num_prior_games / (62 * 62 * 62) % 62) as usize] as char);
-                        game_id.push(BASE62[(num_prior_games / (62 * 62) % 62) as usize] as char);
-                        game_id.push(BASE62[(num_prior_games / 62 % 62) as usize] as char);
-                        game_id.push(BASE62[(num_prior_games % 62) as usize] as char);
-                        game_state.reset_and_draw_tiles_double_ended(&game_config, &mut rng);
-                        loop {
-                            num_moves += 1;
-
-                            game_state.players[game_state.turn as usize]
-                                .rack
-                                .sort_unstable();
-                            let cur_rack = &game_state.current_player().rack;
-
-                            let old_bag_len = game_state.bag.len();
-                            if SUMMARIZE && old_bag_len > 0 {
-                                cur_rack_as_vec.clone_from(cur_rack);
-                            }
-
-                            let board_snapshot = &movegen::BoardSnapshot {
-                                board_tiles: &game_state.board_tiles,
-                                game_config: &game_config,
-                                kwg: &kwg,
-                                klv: if game_state.turn == 0 {
-                                    &arc_klv0
-                                } else {
-                                    &arc_klv1
-                                },
-                            };
-
-                            // supplement the undersampled thread racks.
-                            if SUMMARIZE && old_bag_len > 0 && !undersampled_thread_racks.is_empty() {
-                                let chosen_undersampled_thread_rack_index =
-                                    rng.random_range(0..undersampled_thread_racks.len());
-                                move_generator.gen_moves_unfiltered(&movegen::GenMovesParams {
-                                    board_snapshot,
-                                    rack: &undersampled_thread_racks
-                                        [chosen_undersampled_thread_rack_index],
-                                    max_gen: 1,
-                                    num_exchanges_by_this_player: game_state
-                                        .current_player()
-                                        .num_exchanges,
-                                    always_include_pass: false,
-                                });
-                                let plays = &move_generator.plays;
-                                let play = &plays[0];
-
-                                // opponent calls director if two Q's on board.
-                                let is_possible = match &play.play {
-                                    movegen::Play::Exchange { .. } => true,
-                                    movegen::Play::Place { word, .. } => {
-                                        unseen_tally.clone_from_slice(&alphabet_freqs);
-                                        game_state
-                                            .board_tiles
-                                            .iter()
-                                            .filter_map(|&tile| {
-                                                if tile != 0 {
-                                                    Some(tile & !((tile as i8) >> 7) as u8)
-                                                } else {
-                                                    None
-                                                }
-                                            })
-                                            .for_each(|t| unseen_tally[t as usize] -= 1);
-                                        word.iter()
-                                            .filter_map(|&tile| {
-                                                if tile != 0 {
-                                                    Some(tile & !((tile as i8) >> 7) as u8)
-                                                } else {
-                                                    None
-                                                }
-                                            })
-                                            .all(|t| {
-                                                if unseen_tally[t as usize] > 0 {
-                                                    unseen_tally[t as usize] -= 1;
-                                                    true
-                                                } else {
-                                                    false
-                                                }
-                                            })
-                                    }
-                                };
-
-                                if is_possible {
-                                    let rounded_equity = play.equity.as_f64(); // no rounding
-                                    thread_full_rack_map
-                                        .entry(
-                                            undersampled_thread_racks
-                                                [chosen_undersampled_thread_rack_index][..]
-                                                .into(),
-                                        )
-                                        .and_modify(|e| {
-                                            e.equity += rounded_equity;
-                                            e.count += 1;
-                                        })
-                                        .or_insert(Cumulate {
-                                            equity: rounded_equity,
-                                            count: 1,
-                                        });
-                                    undersampled_thread_racks
-                                        .swap_remove(chosen_undersampled_thread_rack_index);
-                                    if undersampling_remediation_countdown
-                                        .fetch_sub(1, std::sync::atomic::Ordering::Relaxed)
-                                        <= 0
+                            undersampling_remediation_submission
+                                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                            // wait until all threads rendezvous here.
+                            while undersampling_remediation_submission
+                                .load(std::sync::atomic::Ordering::Relaxed)
+                                != num_threads as u64
+                            {}
+                            match undersampling_remediation_state.compare_exchange(
+                                0,
+                                1,
+                                std::sync::atomic::Ordering::Relaxed,
+                                std::sync::atomic::Ordering::Relaxed,
+                            ) {
+                                Ok(_) => {
+                                    // this thread is responsible to iterate the possible racks.
                                     {
-                                        // bounce back. this is why it needs to be signed (i64 not u64).
-                                        undersampling_remediation_countdown
-                                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                                        // force a global reset.
-                                        undersampling_remediation_generation_id
-                                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                                        let mut mutex_guard = mutexed_stuffs.lock().unwrap();
+                                        std::mem::swap(
+                                            &mut thread_full_rack_map,
+                                            &mut mutex_guard.full_rack_map,
+                                        );
+                                        generate_exchanges(&mut ExchangeEnv {
+                                            found_exchange_move: |rack_bytes: &[u8]| {
+                                                let rack_freq = thread_full_rack_map
+                                                    .get(rack_bytes)
+                                                    .map_or(0, |v| v.count);
+                                                if rack_freq < min_samples_per_rack {
+                                                    mutex_guard
+                                                        .undersampled_racks
+                                                        .push(rack_bytes.into());
+                                                }
+                                            },
+                                            rack_tally: &mut alphabet_freqs,
+                                            min_len: game_config.rack_size(),
+                                            max_len: game_config.rack_size(),
+                                            exchange_buffer: &mut exchange_buffer,
+                                        });
+                                        std::mem::swap(
+                                            &mut thread_full_rack_map,
+                                            &mut mutex_guard.full_rack_map,
+                                        );
                                     }
+                                    undersampling_remediation_state
+                                        .compare_exchange(
+                                            1,
+                                            2,
+                                            std::sync::atomic::Ordering::Relaxed,
+                                            std::sync::atomic::Ordering::Relaxed,
+                                        )
+                                        .unwrap();
                                 }
-
-                                let current_undersampling_remediation_generation_id =
-                                    undersampling_remediation_generation_id
-                                        .load(std::sync::atomic::Ordering::Relaxed);
-                                if undersampling_remediation_thread_generation_id
-                                    != current_undersampling_remediation_generation_id
-                                {
-                                    undersampling_remediation_thread_generation_id =
-                                        current_undersampling_remediation_generation_id;
-                                    // reassess which racks are still undersampled after multiple threads worked on them.
-                                    undersampled_thread_racks.clear();
+                                Err(_) => {
+                                    // another thread is contemporaneously iterating the possible racks.
+                                    while undersampling_remediation_state
+                                        .load(std::sync::atomic::Ordering::Relaxed)
+                                        <= 1
+                                    {}
                                 }
                             }
+                            undersampling_remediation_thread_begun = true;
+                        }
+                        if undersampled_thread_racks.is_empty() {
+                            let mut mutex_guard = mutexed_stuffs.lock().unwrap();
+                            for (k, thread_v) in thread_full_rack_map.iter() {
+                                if thread_v.count > 0 {
+                                    mutex_guard
+                                        .full_rack_map
+                                        .entry(k[..].into())
+                                        .and_modify(|v| {
+                                            v.equity += thread_v.equity;
+                                            v.count += thread_v.count;
+                                        })
+                                        .or_insert(thread_v.clone());
+                                }
+                            }
+                            thread_full_rack_map.clear();
+                            // this part does not take into account work already done by other threads.
+                            let mut num_moves_to_force = 0u64;
+                            std::mem::swap(
+                                &mut thread_full_rack_map,
+                                &mut mutex_guard.full_rack_map,
+                            );
+                            mutex_guard.undersampled_racks.retain(
+                                |rack_bytes: &bites::Bites| {
+                                    let rack_freq = thread_full_rack_map
+                                        .get(rack_bytes)
+                                        .map_or(0, |v| v.count);
+                                    if rack_freq < min_samples_per_rack {
+                                        num_moves_to_force += min_samples_per_rack - rack_freq;
+                                        true
+                                    } else {
+                                        false
+                                    }
+                                },
+                            );
+                            std::mem::swap(
+                                &mut thread_full_rack_map,
+                                &mut mutex_guard.full_rack_map,
+                            );
+                            undersampled_thread_racks
+                                .clone_from(&mutex_guard.undersampled_racks);
+                            mutex_guard.undersampling_comment.clear();
+                            if num_moves_to_force != 0 {
+                                let num_undersampled_racks =
+                                    mutex_guard.undersampled_racks.len();
+                                write!(
+                                    mutex_guard.undersampling_comment,
+                                    " (need to force {num_undersampled_racks} racks over {num_moves_to_force} moves)"
+                                )
+                                .unwrap();
+                            }
+                            undersampling_remediation_countdown.store(
+                                num_moves_to_force as i64,
+                                std::sync::atomic::Ordering::Relaxed,
+                            );
 
+                            if undersampled_thread_racks.is_empty() {
+                                // really done. this thread need not play more games.
+                                num_processed_games
+                                    .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+                                break;
+                            }
+
+                            // if there are too few unique racks, repeat them.
+                            // oversampling is better than locking up mutex.
+                            // use floor division to find the ideal number.
+                            let ideal_number_of_undersampled_thread_racks = (num_threads * 32)
+                                / undersampled_thread_racks.len()
+                                * undersampled_thread_racks.len();
+
+                            // if there are too many unique racks, this no-ops.
+                            // the ideal number would be zero but this is fine.
+                            while undersampled_thread_racks.len()
+                                < ideal_number_of_undersampled_thread_racks
+                            {
+                                undersampled_thread_racks.extend_from_within(
+                                    ..undersampled_thread_racks.len().min(
+                                        ideal_number_of_undersampled_thread_racks
+                                            - undersampled_thread_racks.len(),
+                                    ),
+                                );
+                            }
+                        }
+                    }
+
+                    num_moves = 0;
+                    num_bingos.iter_mut().for_each(|m| *m = 0);
+                    num_turns.iter_mut().for_each(|m| *m = 0);
+                    game_id.clear();
+                    // random prefix. 62 ** 4 == 14776336, hopefully enough entropy.
+                    for _ in 0..4 {
+                        game_id.push(*BASE62.choose(&mut rng).unwrap() as char);
+                    }
+                    // wrapping sequence number. 62 ** 4 == 14776336.
+                    num_prior_games = num_prior_games.wrapping_add(1);
+                    game_id
+                        .push(BASE62[(num_prior_games / (62 * 62 * 62) % 62) as usize] as char);
+                    game_id.push(BASE62[(num_prior_games / (62 * 62) % 62) as usize] as char);
+                    game_id.push(BASE62[(num_prior_games / 62 % 62) as usize] as char);
+                    game_id.push(BASE62[(num_prior_games % 62) as usize] as char);
+                    game_state.reset_and_draw_tiles_double_ended(&game_config, &mut rng);
+                    loop {
+                        num_moves += 1;
+
+                        game_state.players[game_state.turn as usize]
+                            .rack
+                            .sort_unstable();
+                        let cur_rack = &game_state.current_player().rack;
+
+                        let old_bag_len = game_state.bag.len();
+                        if SUMMARIZE && old_bag_len > 0 {
+                            cur_rack_as_vec.clone_from(cur_rack);
+                        }
+
+                        let board_snapshot = &movegen::BoardSnapshot {
+                            board_tiles: &game_state.board_tiles,
+                            game_config: &game_config,
+                            kwg: &kwg,
+                            klv: if game_state.turn == 0 {
+                                &arc_klv0
+                            } else {
+                                &arc_klv1
+                            },
+                        };
+
+                        // supplement the undersampled thread racks.
+                        if SUMMARIZE && old_bag_len > 0 && !undersampled_thread_racks.is_empty() {
+                            let chosen_undersampled_thread_rack_index =
+                                rng.random_range(0..undersampled_thread_racks.len());
                             move_generator.gen_moves_unfiltered(&movegen::GenMovesParams {
                                 board_snapshot,
-                                rack: cur_rack,
+                                rack: &undersampled_thread_racks
+                                    [chosen_undersampled_thread_rack_index],
                                 max_gen: 1,
                                 num_exchanges_by_this_player: game_state
                                     .current_player()
                                     .num_exchanges,
                                 always_include_pass: false,
                             });
-
                             let plays = &move_generator.plays;
                             let play = &plays[0];
-                            if WRITE_LOGS {
-                                cur_rack_ser.clear();
-                                for &tile in cur_rack.iter() {
-                                    cur_rack_ser
-                                        .push_str(game_config.alphabet().of_rack(tile).unwrap());
-                                }
 
-                                aft_rack.clone_from(cur_rack);
-                                match &play.play {
-                                    movegen::Play::Exchange { tiles } => {
-                                        game_state::use_tiles(&mut aft_rack, tiles.iter().copied())
-                                            .unwrap();
-                                    }
-                                    movegen::Play::Place { word, .. } => {
-                                        game_state::use_tiles(
-                                            &mut aft_rack,
-                                            word.iter().filter_map(|&tile| {
-                                                if tile != 0 {
-                                                    Some(tile & !((tile as i8) >> 7) as u8)
-                                                } else {
-                                                    None
-                                                }
-                                            }),
-                                        )
-                                        .unwrap();
-                                    }
-                                }
-                                aft_rack.sort_unstable();
-                                aft_rack_ser.clear();
-                                for &tile in aft_rack.iter() {
-                                    aft_rack_ser
-                                        .push_str(game_config.alphabet().of_rack(tile).unwrap());
-                                }
-
-                                play_fmt.clear();
-                                match &play.play {
-                                    movegen::Play::Exchange { tiles } => {
-                                        if tiles.is_empty() {
-                                            play_fmt.push_str("(Pass)");
-                                        } else {
-                                            let alphabet = game_config.alphabet();
-                                            play_fmt.push_str("(exch ");
-                                            for &tile in tiles.iter() {
-                                                play_fmt.push_str(alphabet.of_rack(tile).unwrap());
-                                            }
-                                            play_fmt.push(')');
-                                        }
-                                    }
-                                    movegen::Play::Place {
-                                        down,
-                                        lane,
-                                        idx,
-                                        word,
-                                        ..
-                                    } => {
-                                        let alphabet = game_config.alphabet();
-                                        if *down {
-                                            write!(
-                                                play_fmt,
-                                                "{}{} ",
-                                                display::column(*lane),
-                                                idx + 1
-                                            )
-                                            .unwrap();
-                                        } else {
-                                            write!(
-                                                play_fmt,
-                                                "{}{} ",
-                                                lane + 1,
-                                                display::column(*idx)
-                                            )
-                                            .unwrap();
-                                        }
-                                        for &tile in word.iter() {
-                                            if tile == 0 {
-                                                play_fmt.push('.');
-                                            } else {
-                                                play_fmt.push_str(alphabet.of_board(tile).unwrap());
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-
-                            let play_score = match &play.play {
-                                movegen::Play::Exchange { .. } => 0,
-                                movegen::Play::Place { score, .. } => *score,
-                            };
-
-                            let tiles_played = match &play.play {
-                                movegen::Play::Exchange { tiles } => tiles.len(),
+                            // opponent calls director if two Q's on board.
+                            let is_possible = match &play.play {
+                                movegen::Play::Exchange { .. } => true,
                                 movegen::Play::Place { word, .. } => {
-                                    word.iter().filter(|&&tile| tile != 0).count()
+                                    unseen_tally.clone_from_slice(&alphabet_freqs);
+                                    game_state
+                                        .board_tiles
+                                        .iter()
+                                        .filter_map(|&tile| {
+                                            if tile != 0 {
+                                                Some(tile & !((tile as i8) >> 7) as u8)
+                                            } else {
+                                                None
+                                            }
+                                        })
+                                        .for_each(|t| unseen_tally[t as usize] -= 1);
+                                    word.iter()
+                                        .filter_map(|&tile| {
+                                            if tile != 0 {
+                                                Some(tile & !((tile as i8) >> 7) as u8)
+                                            } else {
+                                                None
+                                            }
+                                        })
+                                        .all(|t| {
+                                            if unseen_tally[t as usize] > 0 {
+                                                unseen_tally[t as usize] -= 1;
+                                                true
+                                            } else {
+                                                false
+                                            }
+                                        })
                                 }
                             };
 
-                            match &play.play {
-                                movegen::Play::Exchange { .. } => {}
-                                movegen::Play::Place { .. } => {
-                                    if tiles_played >= game_config.rack_size() as usize {
-                                        num_bingos[game_state.turn as usize] += 1;
-                                    }
-                                }
-                            };
-
-                            game_state.play(&game_config, &mut rng, &play.play).unwrap();
-
-                            let old_turn = game_state.turn;
-                            num_turns[old_turn as usize] += 1;
-                            game_state.next_turn();
-                            let new_turn = game_state.turn;
-                            game_state.turn = old_turn;
-
-                            if SUMMARIZE && old_bag_len > 0 {
+                            if is_possible {
                                 let rounded_equity = play.equity.as_f64(); // no rounding
                                 thread_full_rack_map
-                                    .entry(cur_rack_as_vec[..].into())
+                                    .entry(
+                                        undersampled_thread_racks
+                                            [chosen_undersampled_thread_rack_index][..]
+                                            .into(),
+                                    )
                                     .and_modify(|e| {
                                         e.equity += rounded_equity;
                                         e.count += 1;
@@ -1176,158 +1010,322 @@ fn generate_autoplay_logs<
                                         equity: rounded_equity,
                                         count: 1,
                                     });
-                            }
-
-                            if WRITE_LOGS {
-                                equity_fmt.clear();
-                                // no rounding, this used to be {:.3} for compatibility reasons.
-                                write!(equity_fmt, "{}", play.equity).unwrap();
-                            }
-
-                            let res = {
-                                let game_ended =
-                                    game_state.check_game_ended(&game_config, &mut final_scores);
-                                // do not play out the game unnecessarily. this impacts stats.
-                                match game_ended {
-                                    game_state::CheckGameEnded::NotEnded
-                                        if !WRITE_LOGS && old_bag_len == 0 =>
-                                    {
-                                        game_state::CheckGameEnded::PlayedOut
-                                    }
-                                    _ => game_ended,
+                                undersampled_thread_racks
+                                    .swap_remove(chosen_undersampled_thread_rack_index);
+                                if undersampling_remediation_countdown
+                                    .fetch_sub(1, std::sync::atomic::Ordering::Relaxed)
+                                    <= 0
+                                {
+                                    // bounce back. this is why it needs to be signed (i64 not u64).
+                                    undersampling_remediation_countdown
+                                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                                    // force a global reset.
+                                    undersampling_remediation_generation_id
+                                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                                 }
-                            }; match res {
-                                game_state::CheckGameEnded::PlayedOut
-                                | game_state::CheckGameEnded::ZeroScores => {
-                                    let completed_moves = completed_moves
-                                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                                    completed_games
-                                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                                    if WRITE_LOGS {
-                                        batched_csv_log
-                                            .serialize((
-                                                &player_aliases[old_turn as usize],
-                                                &game_id,
-                                                num_moves,
-                                                &cur_rack_ser,
-                                                &play_fmt,
-                                                play_score,
-                                                final_scores[old_turn as usize],
-                                                tiles_played,
-                                                &aft_rack_ser,
-                                                &equity_fmt,
-                                                old_bag_len,
-                                                final_scores[new_turn as usize],
-                                            ))
-                                            .unwrap();
+                            }
+
+                            let current_undersampling_remediation_generation_id =
+                                undersampling_remediation_generation_id
+                                    .load(std::sync::atomic::Ordering::Relaxed);
+                            if undersampling_remediation_thread_generation_id
+                                != current_undersampling_remediation_generation_id
+                            {
+                                undersampling_remediation_thread_generation_id =
+                                    current_undersampling_remediation_generation_id;
+                                // reassess which racks are still undersampled after multiple threads worked on them.
+                                undersampled_thread_racks.clear();
+                            }
+                        }
+
+                        move_generator.gen_moves_unfiltered(&movegen::GenMovesParams {
+                            board_snapshot,
+                            rack: cur_rack,
+                            max_gen: 1,
+                            num_exchanges_by_this_player: game_state
+                                .current_player()
+                                .num_exchanges,
+                            always_include_pass: false,
+                        });
+
+                        let plays = &move_generator.plays;
+                        let play = &plays[0];
+                        if WRITE_LOGS {
+                            cur_rack_ser.clear();
+                            for &tile in cur_rack.iter() {
+                                cur_rack_ser
+                                    .push_str(game_config.alphabet().of_rack(tile).unwrap());
+                            }
+
+                            aft_rack.clone_from(cur_rack);
+                            match &play.play {
+                                movegen::Play::Exchange { tiles } => {
+                                    game_state::use_tiles(&mut aft_rack, tiles.iter().copied())
+                                        .unwrap();
+                                }
+                                movegen::Play::Place { word, .. } => {
+                                    game_state::use_tiles(
+                                        &mut aft_rack,
+                                        word.iter().filter_map(|&tile| {
+                                            if tile != 0 {
+                                                Some(tile & !((tile as i8) >> 7) as u8)
+                                            } else {
+                                                None
+                                            }
+                                        }),
+                                    )
+                                    .unwrap();
+                                }
+                            }
+                            aft_rack.sort_unstable();
+                            aft_rack_ser.clear();
+                            for &tile in aft_rack.iter() {
+                                aft_rack_ser
+                                    .push_str(game_config.alphabet().of_rack(tile).unwrap());
+                            }
+
+                            play_fmt.clear();
+                            match &play.play {
+                                movegen::Play::Exchange { tiles } => {
+                                    if tiles.is_empty() {
+                                        play_fmt.push_str("(Pass)");
+                                    } else {
+                                        let alphabet = game_config.alphabet();
+                                        play_fmt.push_str("(exch ");
+                                        for &tile in tiles.iter() {
+                                            play_fmt.push_str(alphabet.of_rack(tile).unwrap());
+                                        }
+                                        play_fmt.push(')');
                                     }
-                                    batched_csv_game
+                                }
+                                movegen::Play::Place {
+                                    down,
+                                    lane,
+                                    idx,
+                                    word,
+                                    ..
+                                } => {
+                                    let alphabet = game_config.alphabet();
+                                    if *down {
+                                        write!(
+                                            play_fmt,
+                                            "{}{} ",
+                                            display::column(*lane),
+                                            idx + 1
+                                        )
+                                        .unwrap();
+                                    } else {
+                                        write!(
+                                            play_fmt,
+                                            "{}{} ",
+                                            lane + 1,
+                                            display::column(*idx)
+                                        )
+                                        .unwrap();
+                                    }
+                                    for &tile in word.iter() {
+                                        if tile == 0 {
+                                            play_fmt.push('.');
+                                        } else {
+                                            play_fmt.push_str(alphabet.of_board(tile).unwrap());
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        let play_score = match &play.play {
+                            movegen::Play::Exchange { .. } => 0,
+                            movegen::Play::Place { score, .. } => *score,
+                        };
+
+                        let tiles_played = match &play.play {
+                            movegen::Play::Exchange { tiles } => tiles.len(),
+                            movegen::Play::Place { word, .. } => {
+                                word.iter().filter(|&&tile| tile != 0).count()
+                            }
+                        };
+
+                        match &play.play {
+                            movegen::Play::Exchange { .. } => {}
+                            movegen::Play::Place { .. } => {
+                                if tiles_played >= game_config.rack_size() as usize {
+                                    num_bingos[game_state.turn as usize] += 1;
+                                }
+                            }
+                        };
+
+                        game_state.play(&game_config, &mut rng, &play.play).unwrap();
+
+                        let old_turn = game_state.turn;
+                        num_turns[old_turn as usize] += 1;
+                        game_state.next_turn();
+                        let new_turn = game_state.turn;
+                        game_state.turn = old_turn;
+
+                        if SUMMARIZE && old_bag_len > 0 {
+                            let rounded_equity = play.equity.as_f64(); // no rounding
+                            thread_full_rack_map
+                                .entry(cur_rack_as_vec[..].into())
+                                .and_modify(|e| {
+                                    e.equity += rounded_equity;
+                                    e.count += 1;
+                                })
+                                .or_insert(Cumulate {
+                                    equity: rounded_equity,
+                                    count: 1,
+                                });
+                        }
+
+                        if WRITE_LOGS {
+                            equity_fmt.clear();
+                            // no rounding, this used to be {:.3} for compatibility reasons.
+                            write!(equity_fmt, "{}", play.equity).unwrap();
+                        }
+
+                        let res = {
+                            let game_ended =
+                                game_state.check_game_ended(&game_config, &mut final_scores);
+                            // do not play out the game unnecessarily. this impacts stats.
+                            match game_ended {
+                                game_state::CheckGameEnded::NotEnded
+                                    if !WRITE_LOGS && old_bag_len == 0 =>
+                                {
+                                    game_state::CheckGameEnded::PlayedOut
+                                }
+                                _ => game_ended,
+                            }
+                        }; match res {
+                            game_state::CheckGameEnded::PlayedOut
+                            | game_state::CheckGameEnded::ZeroScores => {
+                                let completed_moves = completed_moves
+                                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                                completed_games
+                                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                                if WRITE_LOGS {
+                                    batched_csv_log
                                         .serialize((
+                                            &player_aliases[old_turn as usize],
                                             &game_id,
-                                            &final_scores,
-                                            &num_bingos,
-                                            &num_turns,
-                                            &player_aliases[0],
+                                            num_moves,
+                                            &cur_rack_ser,
+                                            &play_fmt,
+                                            play_score,
+                                            final_scores[old_turn as usize],
+                                            tiles_played,
+                                            &aft_rack_ser,
+                                            &equity_fmt,
+                                            old_bag_len,
+                                            final_scores[new_turn as usize],
                                         ))
                                         .unwrap();
-                                    num_batched_games_here += 1;
-                                    if num_batched_games_here >= batch_size {
-                                        let logged_games = logged_games.fetch_add(
-                                            num_batched_games_here,
-                                            std::sync::atomic::Ordering::Relaxed,
-                                        ) + num_batched_games_here;
-                                        num_batched_games_here = 0;
-                                        let mut batched_csv_log_buf =
-                                            batched_csv_log.into_inner().unwrap();
-                                        let mut batched_csv_game_buf =
-                                            batched_csv_game.into_inner().unwrap();
-                                        let elapsed_time_secs = t0.elapsed().as_secs();
-                                        {
-                                            let mut mutex_guard = mutexed_stuffs.lock().unwrap();
-                                            if WRITE_LOGS
-                                                && let Some(c) = &mut mutex_guard.csv_log_writer {
-                                                    c.write_all(&batched_csv_log_buf).unwrap()
-                                                }
-                                            mutex_guard
-                                                .csv_game_writer
-                                                .write_all(&batched_csv_game_buf)
-                                                .unwrap();
-                                            if mutex_guard.tick_periods.update(elapsed_time_secs) {
-                                                eprint!(
-                                                    "After {elapsed_time_secs} seconds, have logged {logged_games} games ({completed_moves} moves)"
-                                                );
-                                                if !mutex_guard.undersampling_comment.is_empty() {
-                                                    eprint!("{}", mutex_guard.undersampling_comment);
-                                                    let num_todo =
-                                                        undersampling_remediation_countdown.load(
-                                                            std::sync::atomic::Ordering::Relaxed,
-                                                        );
-                                                    if num_todo > 0 {
-                                                        eprint!(" (to do: {num_todo})");
-                                                    }
-                                                }
-                                                eprintln!(" into {run_identifier}");
-                                            }
-                                        }
-                                        batched_csv_log_buf.clear();
-                                        batched_csv_log =
-                                            csv::Writer::from_writer(batched_csv_log_buf);
-                                        batched_csv_game_buf.clear();
-                                        batched_csv_game =
-                                            csv::Writer::from_writer(batched_csv_game_buf);
-                                    }
-                                    break;
                                 }
-                                game_state::CheckGameEnded::NotEnded => {}
-                            }
-
-                            if WRITE_LOGS {
-                                batched_csv_log
+                                batched_csv_game
                                     .serialize((
-                                        &player_aliases[old_turn as usize],
                                         &game_id,
-                                        num_moves,
-                                        &cur_rack_ser,
-                                        &play_fmt,
-                                        play_score,
-                                        game_state.players[old_turn as usize].score,
-                                        tiles_played,
-                                        &aft_rack_ser,
-                                        &equity_fmt,
-                                        old_bag_len,
-                                        game_state.players[new_turn as usize].score,
+                                        &final_scores,
+                                        &num_bingos,
+                                        &num_turns,
+                                        &player_aliases[0],
                                     ))
                                     .unwrap();
+                                num_batched_games_here += 1;
+                                if num_batched_games_here >= batch_size {
+                                    let logged_games = logged_games.fetch_add(
+                                        num_batched_games_here,
+                                        std::sync::atomic::Ordering::Relaxed,
+                                    ) + num_batched_games_here;
+                                    num_batched_games_here = 0;
+                                    let mut batched_csv_log_buf =
+                                        batched_csv_log.into_inner().unwrap();
+                                    let mut batched_csv_game_buf =
+                                        batched_csv_game.into_inner().unwrap();
+                                    let elapsed_time_secs = t0.elapsed().as_secs();
+                                    {
+                                        let mut mutex_guard = mutexed_stuffs.lock().unwrap();
+                                        if WRITE_LOGS
+                                            && let Some(c) = &mut mutex_guard.csv_log_writer {
+                                                c.write_all(&batched_csv_log_buf).unwrap()
+                                            }
+                                        mutex_guard
+                                            .csv_game_writer
+                                            .write_all(&batched_csv_game_buf)
+                                            .unwrap();
+                                        if mutex_guard.tick_periods.update(elapsed_time_secs) {
+                                            eprint!(
+                                                "After {elapsed_time_secs} seconds, have logged {logged_games} games ({completed_moves} moves)"
+                                            );
+                                            if !mutex_guard.undersampling_comment.is_empty() {
+                                                eprint!("{}", mutex_guard.undersampling_comment);
+                                                let num_todo =
+                                                    undersampling_remediation_countdown.load(
+                                                        std::sync::atomic::Ordering::Relaxed,
+                                                    );
+                                                if num_todo > 0 {
+                                                    eprint!(" (to do: {num_todo})");
+                                                }
+                                            }
+                                            eprintln!(" into {run_identifier}");
+                                        }
+                                    }
+                                    batched_csv_log_buf.clear();
+                                    batched_csv_log =
+                                        csv::Writer::from_writer(batched_csv_log_buf);
+                                    batched_csv_game_buf.clear();
+                                    batched_csv_game =
+                                        csv::Writer::from_writer(batched_csv_game_buf);
+                                }
+                                break;
                             }
-                            completed_moves.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                            game_state.turn = new_turn;
+                            game_state::CheckGameEnded::NotEnded => {}
                         }
+
+                        if WRITE_LOGS {
+                            batched_csv_log
+                                .serialize((
+                                    &player_aliases[old_turn as usize],
+                                    &game_id,
+                                    num_moves,
+                                    &cur_rack_ser,
+                                    &play_fmt,
+                                    play_score,
+                                    game_state.players[old_turn as usize].score,
+                                    tiles_played,
+                                    &aft_rack_ser,
+                                    &equity_fmt,
+                                    old_bag_len,
+                                    game_state.players[new_turn as usize].score,
+                                ))
+                                .unwrap();
+                        }
+                        completed_moves.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        game_state.turn = new_turn;
                     }
+                }
 
-                    let batched_csv_log_buf = batched_csv_log.into_inner().unwrap();
-                    let batched_csv_game_buf = batched_csv_game.into_inner().unwrap();
-                    let mut mutex_guard = mutexed_stuffs.lock().unwrap();
-                    if WRITE_LOGS
-                        && let Some(c) = &mut mutex_guard.csv_log_writer {
-                            c.write_all(&batched_csv_log_buf).unwrap();
-                        }
-                    mutex_guard
-                        .csv_game_writer
-                        .write_all(&batched_csv_game_buf)
-                        .unwrap();
+                let batched_csv_log_buf = batched_csv_log.into_inner().unwrap();
+                let batched_csv_game_buf = batched_csv_game.into_inner().unwrap();
+                let mut mutex_guard = mutexed_stuffs.lock().unwrap();
+                if WRITE_LOGS
+                    && let Some(c) = &mut mutex_guard.csv_log_writer {
+                        c.write_all(&batched_csv_log_buf).unwrap();
+                    }
+                mutex_guard
+                    .csv_game_writer
+                    .write_all(&batched_csv_game_buf)
+                    .unwrap();
 
-                    if SUMMARIZE {
-                        for (k, thread_v) in thread_full_rack_map.into_iter() {
-                            if thread_v.count > 0 {
-                                mutex_guard
-                                    .full_rack_map
-                                    .entry(k)
-                                    .and_modify(|v| {
-                                        v.equity += thread_v.equity;
-                                        v.count += thread_v.count;
-                                    })
-                                    .or_insert(thread_v);
-                            }
+                if SUMMARIZE {
+                    for (k, thread_v) in thread_full_rack_map.into_iter() {
+                        if thread_v.count > 0 {
+                            mutex_guard
+                                .full_rack_map
+                                .entry(k)
+                                .and_modify(|v| {
+                                    v.equity += thread_v.equity;
+                                    v.count += thread_v.count;
+                                })
+                                .or_insert(thread_v);
                         }
                     }
                 }
@@ -1947,245 +1945,243 @@ fn discover_playability<N: kwg::Node + Sync + Send, L: kwg::Node + Sync + Send>(
             let completed_moves = std::sync::Arc::clone(&completed_moves);
             let mutexed_stuffs = std::sync::Arc::clone(&mutexed_stuffs);
             threads.push(s.spawn(move || {
-                {
-                    let mut rng = rand::rngs::ChaCha20Rng::seed_from_u64(seed);
-                    let mut move_generator = movegen::KurniaMoveGenerator::new(&game_config);
-                    let mut game_state = game_state::GameState::new(&game_config);
-                    let mut final_scores = vec![0; game_config.num_players() as usize];
-                    let mut num_batched_games_here = 0;
-                    let mut thread_full_word_map =
-                        fash::MyHashMap::<bites::Bites, Cumulate>::default();
-                    let mut word_iter = move_filter::LimitedVocabChecker::new();
-                    let mut unjumble_buf = match game_config.game_rules() {
-                        game_config::GameRules::Classic => Vec::new(),
-                        game_config::GameRules::Jumbled => Vec::with_capacity(
-                            game_config
-                                .board_layout()
-                                .dim()
-                                .rows
-                                .max(game_config.board_layout().dim().cols)
-                                as usize,
-                        ),
-                    };
-                    let mut tally_word =
-                        |v: &mut Vec<(bites::Bites, usize)>, num_plays: usize, w: &[u8]| {
-                            match game_config.game_rules() {
-                                game_config::GameRules::Classic => {
+                let mut rng = rand::rngs::ChaCha20Rng::seed_from_u64(seed);
+                let mut move_generator = movegen::KurniaMoveGenerator::new(&game_config);
+                let mut game_state = game_state::GameState::new(&game_config);
+                let mut final_scores = vec![0; game_config.num_players() as usize];
+                let mut num_batched_games_here = 0;
+                let mut thread_full_word_map =
+                    fash::MyHashMap::<bites::Bites, Cumulate>::default();
+                let mut word_iter = move_filter::LimitedVocabChecker::new();
+                let mut unjumble_buf = match game_config.game_rules() {
+                    game_config::GameRules::Classic => Vec::new(),
+                    game_config::GameRules::Jumbled => Vec::with_capacity(
+                        game_config
+                            .board_layout()
+                            .dim()
+                            .rows
+                            .max(game_config.board_layout().dim().cols)
+                            as usize,
+                    ),
+                };
+                let mut tally_word =
+                    |v: &mut Vec<(bites::Bites, usize)>, num_plays: usize, w: &[u8]| {
+                        match game_config.game_rules() {
+                            game_config::GameRules::Classic => {
+                                v.push((w.into(), num_plays));
+                            }
+                            game_config::GameRules::Jumbled => {
+                                if w.windows(2).all(|x| x[0] <= x[1]) {
                                     v.push((w.into(), num_plays));
-                                }
-                                game_config::GameRules::Jumbled => {
-                                    if w.windows(2).all(|x| x[0] <= x[1]) {
-                                        v.push((w.into(), num_plays));
-                                    } else {
-                                        // bites::Bites does not DerefMut.
-                                        let w_len = w.len();
-                                        unjumble_buf.resize(w_len.max(unjumble_buf.len()), 0);
-                                        unjumble_buf[..w_len].clone_from_slice(w);
-                                        unjumble_buf[..w_len].sort_unstable();
-                                        v.push((unjumble_buf[..w_len].into(), num_plays));
-                                    }
+                                } else {
+                                    // bites::Bites does not DerefMut.
+                                    let w_len = w.len();
+                                    unjumble_buf.resize(w_len.max(unjumble_buf.len()), 0);
+                                    unjumble_buf[..w_len].clone_from_slice(w);
+                                    unjumble_buf[..w_len].sort_unstable();
+                                    v.push((unjumble_buf[..w_len].into(), num_plays));
                                 }
                             }
-                        };
-                    // words played in the same turn (hooks) get the same usize.
-                    let mut vec_played = Vec::<(bites::Bites, usize)>::new();
+                        }
+                    };
+                // words played in the same turn (hooks) get the same usize.
+                let mut vec_played = Vec::<(bites::Bites, usize)>::new();
+                loop {
+                    let num_prior_games =
+                        num_processed_games.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    if num_prior_games >= num_games {
+                        num_processed_games.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+                        break;
+                    }
+                    rng.set_stream(num_prior_games);
+
+                    game_state.reset_and_draw_tiles_double_ended(&game_config, &mut rng);
                     loop {
-                        let num_prior_games =
-                            num_processed_games.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                        if num_prior_games >= num_games {
-                            num_processed_games.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+                        game_state.players[game_state.turn as usize]
+                            .rack
+                            .sort_unstable();
+                        let cur_rack = &game_state.current_player().rack;
+
+                        let old_bag_len = game_state.bag.len();
+
+                        let board_snapshot = &movegen::BoardSnapshot {
+                            board_tiles: &game_state.board_tiles,
+                            game_config: &game_config,
+                            kwg: &kwg,
+                            klv: &klv,
+                        };
+
+                        let moves_made_before_ending: u64 = if old_bag_len > 0 {
+                            let mut best_equity_so_far = equity::Equity::NEG_INFINITY;
+                            let mut num_plays = 0usize;
+                            vec_played.clear();
+                            move_generator.gen_moves_filtered(
+                                &movegen::GenMovesParams {
+                                    board_snapshot,
+                                    rack: cur_rack,
+                                    max_gen: 2, // to allow finding equal-equity plays.
+                                    num_exchanges_by_this_player: game_state
+                                        .current_player()
+                                        .num_exchanges,
+                                    always_include_pass: false,
+                                },
+                                |_down: bool,
+                                 _lane: i8,
+                                 _idx: i8,
+                                 _word: &[u8],
+                                 _score: i32| true,
+                                |leave_value: i32| leave_value,
+                                |equity: equity::Equity, play: &movegen::Play| {
+                                    match equity.cmp(&best_equity_so_far) {
+                                        std::cmp::Ordering::Greater => {
+                                            best_equity_so_far = equity;
+                                            vec_played.clear();
+                                            num_plays = 0;
+                                            match play {
+                                                movegen::Play::Exchange { .. } => {}
+                                                movegen::Play::Place {
+                                                    down,
+                                                    lane,
+                                                    idx,
+                                                    word,
+                                                    ..
+                                                } => {
+                                                    word_iter.words_placed_are_ok(
+                                                        board_snapshot,
+                                                        *down,
+                                                        *lane,
+                                                        *idx,
+                                                        &word[..],
+                                                        |w: &[u8]| {
+                                                            tally_word(
+                                                                &mut vec_played,
+                                                                num_plays,
+                                                                w,
+                                                            );
+                                                            true
+                                                        },
+                                                    );
+                                                }
+                                            }
+                                            num_plays += 1;
+                                            true
+                                        }
+                                        std::cmp::Ordering::Equal => {
+                                            match play {
+                                                movegen::Play::Exchange { .. } => {}
+                                                movegen::Play::Place {
+                                                    down,
+                                                    lane,
+                                                    idx,
+                                                    word,
+                                                    ..
+                                                } => {
+                                                    word_iter.words_placed_are_ok(
+                                                        board_snapshot,
+                                                        *down,
+                                                        *lane,
+                                                        *idx,
+                                                        &word[..],
+                                                        |w: &[u8]| {
+                                                            tally_word(
+                                                                &mut vec_played,
+                                                                num_plays,
+                                                                w,
+                                                            );
+                                                            true
+                                                        },
+                                                    );
+                                                }
+                                            }
+                                            num_plays += 1;
+                                            false // ensure top two have different equities.
+                                        }
+                                        std::cmp::Ordering::Less => false,
+                                    }
+                                },
+                            );
+                            // num_plays == 0 means all moves were exchanges/pass.
+                            if num_plays > 0 {
+                                vec_played.sort_unstable();
+                                vec_played.dedup(); // playing the same word as main+hook or hook+hook counts once.
+                                // each word gets n/d if played in n of d equally top moves.
+                                let multiplier = (num_plays as f64).recip();
+                                for same_words in vec_played.chunk_by(|a, b| a.0 == b.0) {
+                                    let occurrence = same_words.len() as f64 * multiplier;
+                                    // allocs for long words, but long words are rarely played.
+                                    thread_full_word_map
+                                        .entry(same_words[0].0[..].into())
+                                        .and_modify(|e| {
+                                            e.equity += occurrence;
+                                            e.count += 1;
+                                        })
+                                        .or_insert(Cumulate {
+                                            equity: occurrence,
+                                            count: 1,
+                                        });
+                                }
+                            }
+
+                            let plays = &move_generator.plays;
+                            let play = &plays[0];
+
+                            game_state.play(&game_config, &mut rng, &play.play).unwrap();
+
+                            match game_state.check_game_ended(&game_config, &mut final_scores) {
+                                game_state::CheckGameEnded::PlayedOut
+                                | game_state::CheckGameEnded::ZeroScores => 1,
+                                game_state::CheckGameEnded::NotEnded => !0,
+                            }
+                        } else {
+                            // bag is empty, skip the rest of the game.
+                            0
+                        };
+
+                        if moves_made_before_ending != !0 {
+                            let completed_moves = completed_moves.fetch_add(
+                                moves_made_before_ending,
+                                std::sync::atomic::Ordering::Relaxed,
+                            );
+                            completed_games.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                            num_batched_games_here += 1;
+                            if num_batched_games_here >= batch_size {
+                                // nothing logged, just grab the mutex to report time less often.
+                                let logged_games = logged_games.fetch_add(
+                                    num_batched_games_here,
+                                    std::sync::atomic::Ordering::Relaxed,
+                                ) + num_batched_games_here;
+                                num_batched_games_here = 0;
+                                let elapsed_time_secs = t0.elapsed().as_secs();
+                                let tick_changed = {
+                                    let mut mutex_guard = mutexed_stuffs.lock().unwrap();
+                                    mutex_guard.tick_periods.update(elapsed_time_secs)
+                                };
+                                if tick_changed {
+                                    eprintln!(
+                                        "After {elapsed_time_secs} seconds, have played {logged_games} games ({completed_moves} moves) for {run_identifier}"
+                                    );
+                                }
+                            }
                             break;
                         }
-                        rng.set_stream(num_prior_games);
 
-                        game_state.reset_and_draw_tiles_double_ended(&game_config, &mut rng);
-                        loop {
-                            game_state.players[game_state.turn as usize]
-                                .rack
-                                .sort_unstable();
-                            let cur_rack = &game_state.current_player().rack;
-
-                            let old_bag_len = game_state.bag.len();
-
-                            let board_snapshot = &movegen::BoardSnapshot {
-                                board_tiles: &game_state.board_tiles,
-                                game_config: &game_config,
-                                kwg: &kwg,
-                                klv: &klv,
-                            };
-
-                            let moves_made_before_ending: u64 = if old_bag_len > 0 {
-                                let mut best_equity_so_far = equity::Equity::NEG_INFINITY;
-                                let mut num_plays = 0usize;
-                                vec_played.clear();
-                                move_generator.gen_moves_filtered(
-                                    &movegen::GenMovesParams {
-                                        board_snapshot,
-                                        rack: cur_rack,
-                                        max_gen: 2, // to allow finding equal-equity plays.
-                                        num_exchanges_by_this_player: game_state
-                                            .current_player()
-                                            .num_exchanges,
-                                        always_include_pass: false,
-                                    },
-                                    |_down: bool,
-                                     _lane: i8,
-                                     _idx: i8,
-                                     _word: &[u8],
-                                     _score: i32| true,
-                                    |leave_value: i32| leave_value,
-                                    |equity: equity::Equity, play: &movegen::Play| {
-                                        match equity.cmp(&best_equity_so_far) {
-                                            std::cmp::Ordering::Greater => {
-                                                best_equity_so_far = equity;
-                                                vec_played.clear();
-                                                num_plays = 0;
-                                                match play {
-                                                    movegen::Play::Exchange { .. } => {}
-                                                    movegen::Play::Place {
-                                                        down,
-                                                        lane,
-                                                        idx,
-                                                        word,
-                                                        ..
-                                                    } => {
-                                                        word_iter.words_placed_are_ok(
-                                                            board_snapshot,
-                                                            *down,
-                                                            *lane,
-                                                            *idx,
-                                                            &word[..],
-                                                            |w: &[u8]| {
-                                                                tally_word(
-                                                                    &mut vec_played,
-                                                                    num_plays,
-                                                                    w,
-                                                                );
-                                                                true
-                                                            },
-                                                        );
-                                                    }
-                                                }
-                                                num_plays += 1;
-                                                true
-                                            }
-                                            std::cmp::Ordering::Equal => {
-                                                match play {
-                                                    movegen::Play::Exchange { .. } => {}
-                                                    movegen::Play::Place {
-                                                        down,
-                                                        lane,
-                                                        idx,
-                                                        word,
-                                                        ..
-                                                    } => {
-                                                        word_iter.words_placed_are_ok(
-                                                            board_snapshot,
-                                                            *down,
-                                                            *lane,
-                                                            *idx,
-                                                            &word[..],
-                                                            |w: &[u8]| {
-                                                                tally_word(
-                                                                    &mut vec_played,
-                                                                    num_plays,
-                                                                    w,
-                                                                );
-                                                                true
-                                                            },
-                                                        );
-                                                    }
-                                                }
-                                                num_plays += 1;
-                                                false // ensure top two have different equities.
-                                            }
-                                            std::cmp::Ordering::Less => false,
-                                        }
-                                    },
-                                );
-                                // num_plays == 0 means all moves were exchanges/pass.
-                                if num_plays > 0 {
-                                    vec_played.sort_unstable();
-                                    vec_played.dedup(); // playing the same word as main+hook or hook+hook counts once.
-                                    // each word gets n/d if played in n of d equally top moves.
-                                    let multiplier = (num_plays as f64).recip();
-                                    for same_words in vec_played.chunk_by(|a, b| a.0 == b.0) {
-                                        let occurrence = same_words.len() as f64 * multiplier;
-                                        // allocs for long words, but long words are rarely played.
-                                        thread_full_word_map
-                                            .entry(same_words[0].0[..].into())
-                                            .and_modify(|e| {
-                                                e.equity += occurrence;
-                                                e.count += 1;
-                                            })
-                                            .or_insert(Cumulate {
-                                                equity: occurrence,
-                                                count: 1,
-                                            });
-                                    }
-                                }
-
-                                let plays = &move_generator.plays;
-                                let play = &plays[0];
-
-                                game_state.play(&game_config, &mut rng, &play.play).unwrap();
-
-                                match game_state.check_game_ended(&game_config, &mut final_scores) {
-                                    game_state::CheckGameEnded::PlayedOut
-                                    | game_state::CheckGameEnded::ZeroScores => 1,
-                                    game_state::CheckGameEnded::NotEnded => !0,
-                                }
-                            } else {
-                                // bag is empty, skip the rest of the game.
-                                0
-                            };
-
-                            if moves_made_before_ending != !0 {
-                                let completed_moves = completed_moves.fetch_add(
-                                    moves_made_before_ending,
-                                    std::sync::atomic::Ordering::Relaxed,
-                                );
-                                completed_games.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                                num_batched_games_here += 1;
-                                if num_batched_games_here >= batch_size {
-                                    // nothing logged, just grab the mutex to report time less often.
-                                    let logged_games = logged_games.fetch_add(
-                                        num_batched_games_here,
-                                        std::sync::atomic::Ordering::Relaxed,
-                                    ) + num_batched_games_here;
-                                    num_batched_games_here = 0;
-                                    let elapsed_time_secs = t0.elapsed().as_secs();
-                                    let tick_changed = {
-                                        let mut mutex_guard = mutexed_stuffs.lock().unwrap();
-                                        mutex_guard.tick_periods.update(elapsed_time_secs)
-                                    };
-                                    if tick_changed {
-                                        eprintln!(
-                                            "After {elapsed_time_secs} seconds, have played {logged_games} games ({completed_moves} moves) for {run_identifier}"
-                                        );
-                                    }
-                                }
-                                break;
-                            }
-
-                            completed_moves.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                            game_state.next_turn();
-                        }
+                        completed_moves.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        game_state.next_turn();
                     }
+                }
 
-                    let mut mutex_guard = mutexed_stuffs.lock().unwrap();
+                let mut mutex_guard = mutexed_stuffs.lock().unwrap();
 
-                    for (k, thread_v) in thread_full_word_map.into_iter() {
-                        if thread_v.count > 0 {
-                            mutex_guard
-                                .full_word_map
-                                .entry(k)
-                                .and_modify(|v| {
-                                    v.equity += thread_v.equity;
-                                    v.count += thread_v.count;
-                                })
-                                .or_insert(thread_v);
-                        }
+                for (k, thread_v) in thread_full_word_map.into_iter() {
+                    if thread_v.count > 0 {
+                        mutex_guard
+                            .full_word_map
+                            .entry(k)
+                            .and_modify(|v| {
+                                v.equity += thread_v.equity;
+                                v.count += thread_v.count;
+                            })
+                            .or_insert(thread_v);
                     }
                 }
             }));

--- a/src/main_leave.rs
+++ b/src/main_leave.rs
@@ -712,8 +712,7 @@ fn generate_autoplay_logs<
                 let mut num_batched_games_here = 0;
                 let mut batched_csv_log = csv::Writer::from_writer(Vec::new());
                 let mut batched_csv_game = csv::Writer::from_writer(Vec::new());
-                let mut thread_full_rack_map =
-                    fash::MyHashMap::<bites::Bites, Cumulate>::default();
+                let mut thread_full_rack_map = fash::MyHashMap::<bites::Bites, Cumulate>::default();
                 let mut exchange_buffer = if SUMMARIZE && min_samples_per_rack != 0 {
                     Vec::with_capacity(game_config.rack_size() as usize)
                 } else {
@@ -839,29 +838,26 @@ fn generate_autoplay_logs<
                                 &mut thread_full_rack_map,
                                 &mut mutex_guard.full_rack_map,
                             );
-                            mutex_guard.undersampled_racks.retain(
-                                |rack_bytes: &bites::Bites| {
-                                    let rack_freq = thread_full_rack_map
-                                        .get(rack_bytes)
-                                        .map_or(0, |v| v.count);
+                            mutex_guard
+                                .undersampled_racks
+                                .retain(|rack_bytes: &bites::Bites| {
+                                    let rack_freq =
+                                        thread_full_rack_map.get(rack_bytes).map_or(0, |v| v.count);
                                     if rack_freq < min_samples_per_rack {
                                         num_moves_to_force += min_samples_per_rack - rack_freq;
                                         true
                                     } else {
                                         false
                                     }
-                                },
-                            );
+                                });
                             std::mem::swap(
                                 &mut thread_full_rack_map,
                                 &mut mutex_guard.full_rack_map,
                             );
-                            undersampled_thread_racks
-                                .clone_from(&mutex_guard.undersampled_racks);
+                            undersampled_thread_racks.clone_from(&mutex_guard.undersampled_racks);
                             mutex_guard.undersampling_comment.clear();
                             if num_moves_to_force != 0 {
-                                let num_undersampled_racks =
-                                    mutex_guard.undersampled_racks.len();
+                                let num_undersampled_racks = mutex_guard.undersampled_racks.len();
                                 write!(
                                     mutex_guard.undersampling_comment,
                                     " (need to force {num_undersampled_racks} racks over {num_moves_to_force} moves)"
@@ -912,8 +908,7 @@ fn generate_autoplay_logs<
                     }
                     // wrapping sequence number. 62 ** 4 == 14776336.
                     num_prior_games = num_prior_games.wrapping_add(1);
-                    game_id
-                        .push(BASE62[(num_prior_games / (62 * 62 * 62) % 62) as usize] as char);
+                    game_id.push(BASE62[(num_prior_games / (62 * 62 * 62) % 62) as usize] as char);
                     game_id.push(BASE62[(num_prior_games / (62 * 62) % 62) as usize] as char);
                     game_id.push(BASE62[(num_prior_games / 62 % 62) as usize] as char);
                     game_id.push(BASE62[(num_prior_games % 62) as usize] as char);
@@ -1042,9 +1037,7 @@ fn generate_autoplay_logs<
                             board_snapshot,
                             rack: cur_rack,
                             max_gen: 1,
-                            num_exchanges_by_this_player: game_state
-                                .current_player()
-                                .num_exchanges,
+                            num_exchanges_by_this_player: game_state.current_player().num_exchanges,
                             always_include_pass: false,
                         });
 
@@ -1107,21 +1100,11 @@ fn generate_autoplay_logs<
                                 } => {
                                     let alphabet = game_config.alphabet();
                                     if *down {
-                                        write!(
-                                            play_fmt,
-                                            "{}{} ",
-                                            display::column(*lane),
-                                            idx + 1
-                                        )
-                                        .unwrap();
+                                        write!(play_fmt, "{}{} ", display::column(*lane), idx + 1)
+                                            .unwrap();
                                     } else {
-                                        write!(
-                                            play_fmt,
-                                            "{}{} ",
-                                            lane + 1,
-                                            display::column(*idx)
-                                        )
-                                        .unwrap();
+                                        write!(play_fmt, "{}{} ", lane + 1, display::column(*idx))
+                                            .unwrap();
                                     }
                                     for &tile in word.iter() {
                                         if tile == 0 {
@@ -1195,13 +1178,13 @@ fn generate_autoplay_logs<
                                 }
                                 _ => game_ended,
                             }
-                        }; match res {
+                        };
+                        match res {
                             game_state::CheckGameEnded::PlayedOut
                             | game_state::CheckGameEnded::ZeroScores => {
                                 let completed_moves = completed_moves
                                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                                completed_games
-                                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                                completed_games.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                                 if WRITE_LOGS {
                                     batched_csv_log
                                         .serialize((
@@ -1244,9 +1227,10 @@ fn generate_autoplay_logs<
                                     {
                                         let mut mutex_guard = mutexed_stuffs.lock().unwrap();
                                         if WRITE_LOGS
-                                            && let Some(c) = &mut mutex_guard.csv_log_writer {
-                                                c.write_all(&batched_csv_log_buf).unwrap()
-                                            }
+                                            && let Some(c) = &mut mutex_guard.csv_log_writer
+                                        {
+                                            c.write_all(&batched_csv_log_buf).unwrap()
+                                        }
                                         mutex_guard
                                             .csv_game_writer
                                             .write_all(&batched_csv_game_buf)
@@ -1257,10 +1241,8 @@ fn generate_autoplay_logs<
                                             );
                                             if !mutex_guard.undersampling_comment.is_empty() {
                                                 eprint!("{}", mutex_guard.undersampling_comment);
-                                                let num_todo =
-                                                    undersampling_remediation_countdown.load(
-                                                        std::sync::atomic::Ordering::Relaxed,
-                                                    );
+                                                let num_todo = undersampling_remediation_countdown
+                                                    .load(std::sync::atomic::Ordering::Relaxed);
                                                 if num_todo > 0 {
                                                     eprint!(" (to do: {num_todo})");
                                                 }
@@ -1269,8 +1251,7 @@ fn generate_autoplay_logs<
                                         }
                                     }
                                     batched_csv_log_buf.clear();
-                                    batched_csv_log =
-                                        csv::Writer::from_writer(batched_csv_log_buf);
+                                    batched_csv_log = csv::Writer::from_writer(batched_csv_log_buf);
                                     batched_csv_game_buf.clear();
                                     batched_csv_game =
                                         csv::Writer::from_writer(batched_csv_game_buf);
@@ -1306,10 +1287,9 @@ fn generate_autoplay_logs<
                 let batched_csv_log_buf = batched_csv_log.into_inner().unwrap();
                 let batched_csv_game_buf = batched_csv_game.into_inner().unwrap();
                 let mut mutex_guard = mutexed_stuffs.lock().unwrap();
-                if WRITE_LOGS
-                    && let Some(c) = &mut mutex_guard.csv_log_writer {
-                        c.write_all(&batched_csv_log_buf).unwrap();
-                    }
+                if WRITE_LOGS && let Some(c) = &mut mutex_guard.csv_log_writer {
+                    c.write_all(&batched_csv_log_buf).unwrap();
+                }
                 mutex_guard
                     .csv_game_writer
                     .write_all(&batched_csv_game_buf)
@@ -1950,8 +1930,7 @@ fn discover_playability<N: kwg::Node + Sync + Send, L: kwg::Node + Sync + Send>(
                 let mut game_state = game_state::GameState::new(&game_config);
                 let mut final_scores = vec![0; game_config.num_players() as usize];
                 let mut num_batched_games_here = 0;
-                let mut thread_full_word_map =
-                    fash::MyHashMap::<bites::Bites, Cumulate>::default();
+                let mut thread_full_word_map = fash::MyHashMap::<bites::Bites, Cumulate>::default();
                 let mut word_iter = move_filter::LimitedVocabChecker::new();
                 let mut unjumble_buf = match game_config.game_rules() {
                     game_config::GameRules::Classic => Vec::new(),
@@ -2025,11 +2004,7 @@ fn discover_playability<N: kwg::Node + Sync + Send, L: kwg::Node + Sync + Send>(
                                         .num_exchanges,
                                     always_include_pass: false,
                                 },
-                                |_down: bool,
-                                 _lane: i8,
-                                 _idx: i8,
-                                 _word: &[u8],
-                                 _score: i32| true,
+                                |_down: bool, _lane: i8, _idx: i8, _word: &[u8], _score: i32| true,
                                 |leave_value: i32| leave_value,
                                 |equity: equity::Equity, play: &movegen::Play| {
                                     match equity.cmp(&best_equity_so_far) {

--- a/src/main_leave.rs
+++ b/src/main_leave.rs
@@ -426,7 +426,7 @@ fn main() -> error::Returns<()> {
     confidence that one set of leaves is better.
     if klv is \"-\" or omitted, uses no leave.
     number of game pairs is optional (default 10000).
-    seed is optional; if provided, uses single thread for reproducibility.
+    seed is optional; prints auto-generated seed to stderr if not provided.
   (english can also be catalan, dutch, french, german, norwegian, polish,
     slovene, spanish, super-english, super-catalan)
   (add -big after language, such as dutch-big-autoplay, to use kbwg)


### PR DESCRIPTION
## Summary

- Apply the compare_leaves per-pair-stream pattern (#30) to `english-autoplay` and `english-playability` so seeded runs are multi-threaded and reproducible.
- Drop the old `seed.is_some() -> single-threaded fallback` in autoplay.
- Add an optional `[seed]` arg to `english-playability`.
- Auto-generate + print to stderr when the seed is not supplied.
- Fix stale `-compare` help text that still claimed "uses single thread for reproducibility" -- untrue since #30.
- Remove the now-dead `thread_local! RNG` in `main_leave.rs`.
- Let `cargo fmt` reformat the contents of the `s.spawn(move || { ... })` closures (rustfmt silently skips formatting inside spawn closure bodies, so a few long lines / method chains had drifted out of style).

## Correctness

Each thread builds its own `ChaCha20Rng::seed_from_u64(seed)` and calls `rng.set_stream(game_idx)` before each game. ChaCha20 streams are independent by construction, so each game's RNG output depends only on `(seed, game_idx)` -- not on which thread picks up the game.

Same seed, 3 runs, 500 games of autoplay-summarize-only: record counts byte-identical. f64 equity sums in the summary/playability CSVs may still vary in the last ULP due to non-associative floating-point addition across threads -- same caveat that already applies to `-compare` and `-autoplay-summarize`.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets` (clean per commit)
- [x] `cargo test --release`
- [x] `cargo build --release`
- [x] same-seed determinism: 3 autoplay-summarize-only runs at seed 55555, identical count-only MD5
- [x] same-seed determinism: 3 playability runs at seed 12345, identical count-only MD5
- [x] diff-seed: different MD5 as expected
- [x] unseeded: auto-generates + prints `seed: N` to stderr